### PR TITLE
http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-u

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -71,4 +71,4 @@ debs:
     - openstackx
 
 extra_files:
-  - http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-uec-amd64.tar.gz ami
+  - http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-cloudimg-amd64.tar.gz ami


### PR DESCRIPTION
http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-uec-amd64.tar.gz has been renamed to http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-cloudimg-amd64.tar.gz
