### PR TITLE
Adding back support for creating a novarc file

### DIFF
--- a/chef/cookbooks/nova/templates/default/novarc.erb
+++ b/chef/cookbooks/nova/templates/default/novarc.erb
@@ -13,3 +13,8 @@ export OS_AUTH_KEY=${NOVA_PASSWORD}
 export OS_AUTH_TENANT=${NOVA_PROJECT_ID}
 export OS_AUTH_URL=${NOVA_URL}
 export OS_AUTH_STRATEGY=keystone
+
+# EUCA2OOLs ENV VARIABLES
+export EC2_ACCESS_KEY=${NOVA_USERNAME}
+export EC2_SECRET_KEY=${NOVA_PASSWORD}
+export EC2_URL=http://<%= @nova_api_ip_address %>:8773/services/Cloud


### PR DESCRIPTION
This will create /root/.novarc on the admin node. Sourcing this file will let you run the 'nova' and 'glance' cli's with keystone integration.

There could potentially be an issue as to where this file gets created. It is run under the project role so it should work.. but there could be a dependency on all controller services being on the same physical node.. need to test more to make sure this assumption works.
