### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [23/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -32,6 +32,10 @@
   "deployment": {
     "nova": {
       "crowbar-revision": 0,
+      "element_states": {
+        "nova-multi-controller": [ "readying", "ready", "applying" ],
+        "nova-multi-compute": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "nova-multi-controller" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -72,6 +72,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-nova.json   |    4 ++++
 chef/data_bags/crowbar/bc-template-nova.schema |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
