### PR TITLE
Auth strategy fix

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -93,6 +93,7 @@ vncserver_proxyclient_address=127.0.0.1
 use_deprecated_auth=false
 allow_admin_api=true
 enable_zone_routing=true
+auth_strategy=keystone
 
 # VOLUME
 volume_group=<%= node[:nova][:volume][:volume_name] %>


### PR DESCRIPTION
Without auth_strategy=keystone in nova.conf command "nova image-list" failed with "http 403" 
