### PR TITLE
Patch 1

### DIFF
--- a/chef/cookbooks/nova/recipes/volume.rb
+++ b/chef/cookbooks/nova/recipes/volume.rb
@@ -38,7 +38,7 @@ if node[:nova][:volume][:type] == "local"
   end
 
   bash "create volume group" do
-    code "vgcreate #{volname} `losetup -f --show #{fname}`"
+    code "vgcreate #{volname} `losetup -j #{fname} | cut -f1 -d:`"
     not_if "vgs #{volname}"
   end
 


### PR DESCRIPTION
"losetup -f" will assign a new unused loop device, so we have to call it only one time in the whole recipe.
