### PR TITLE
Fixed vnc packages and config

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -100,6 +100,16 @@ else
 end
 Chef::Log.info("Glance server at #{glance_server_ip}")
 
+vncproxies = search(:node, "recipes:nova\\:\\:vncproxy#{env_filter}") || []
+if vncproxies.length > 0
+  vncproxy = vncproxies[0]
+  vncproxy = node if vncproxy.name == node.name
+  vncproxy_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(vncproxy, "public").address
+else
+  vncproxy_public_ip = nil
+end
+Chef::Log.info("VNCProxy server at #{vncproxy_public_ip}")
+
 cookbook_file "/etc/default/nova-common" do
   source "nova-common"
   owner "root"
@@ -176,7 +186,8 @@ template "/etc/nova/nova.conf" do
             :network_public_ip => network_public_ip,
             :dns_server_public_ip => dns_server_public_ip,
             :glance_server_ip => glance_server_ip,
-            :glance_server_port => glance_server_port
+            :glance_server_port => glance_server_port,
+            :vncproxy_public_ip => vncproxy_public_ip
             )
 end
 

--- a/chef/cookbooks/nova/recipes/vncproxy.rb
+++ b/chef/cookbooks/nova/recipes/vncproxy.rb
@@ -20,7 +20,7 @@
 
 include_recipe "nova::config"
 
-pkgs=%w[python-numpy nova-vncproxy nova-console]
+pkgs=%w[python-numpy nova-vncproxy nova-console nova-consoleauth]
 pkgs.each do |pkg|
   package pkg do
     action :upgrade

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -82,8 +82,10 @@ instance_name_template=instance-%08x
 compute_scheduler_driver=nova.scheduler.filter_scheduler.FilterScheduler
 
 # VNCPROXY
-novncproxy_url=http://<%= @ec2_dmz_host %>:6080/vnc_auto.html
-xvpvncproxy_base_url=http://<%= @ec2_dmz_host %>:6081/console
+<% unless @vncproxy_public_ip.nil? -%>
+novncproxy_base_url=http://<%= @vncproxy_public_ip %>:6080/vnc_auto.html
+xvpvncproxy_base_url=http://<%= @vncproxy_public_ip %>:6081/console
+<% end -%>
 vncserver_listen=<%= node[:nova][:my_ip] %>
 vncserver_proxyclient_address=<%= node[:nova][:my_ip] %>
 

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -81,6 +81,8 @@ debs:
       - nova-doc
       - nova-console
       - nova-xcp-network
+      - python-numpy
+      - nova-consoleauth
   pkgs:
     - euca2ools
     - unzip


### PR DESCRIPTION
Change novncproxy_base_url, xvpvncproxy_base_url to IP address of vncproxy host instead of API address. Because in HA schema nova-api on all hosts. 

Add new package new nova-consoleauth in vncproxy.rb and crowbar.yml. https://bugs.launchpad.net/ubuntu/+source/nova/+bug/959289

Additionally "novnc" package need, but for now it is outdated.
