### PR TITLE
Make the service user configurable for swift and nova [2/3]

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -77,3 +77,5 @@ default[:nova][:network][:flat_network_dhcp_start] = "10.0.0.2"
 default[:nova][:network][:vlan_interface] = "eth1"
 default[:nova][:network][:vlan_start] = 100
 
+default[:nova][:service_user] = "nova"
+default[:nova][:service_password] = "nova"

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -38,8 +38,8 @@ keystone_token = keystone["keystone"]["service"]["token"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"]
 keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
 keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
-keystone_service_user = "nova" # GREG: Fix this
-keystone_service_password = "fredfred" # GREG: Fix this
+keystone_service_user = node["nova"]["service_user"]
+keystone_service_password = node["nova"]["service_password"]
 Chef::Log.info("Keystone server found at #{keystone_address}")
 
 template "/etc/nova/api-paste.ini" do

--- a/chef/cookbooks/nova/recipes/volume.rb
+++ b/chef/cookbooks/nova/recipes/volume.rb
@@ -117,8 +117,8 @@ keystone_token = keystone["keystone"]["service"]["token"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"]
 keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
 keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
-keystone_service_user = "nova" # GREG: Fix this
-keystone_service_password = "fredfred" # GREG: Fix this
+keystone_service_user = node["nova"]["service_user"]
+keystone_service_password = node["nova"]["service_password"]
 Chef::Log.info("Keystone server found at #{keystone_address}")
 
 keystone_register "nova volume wakeup keystone" do

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -4,6 +4,7 @@
   "attributes": {
     "nova": {
       "keystone_instance": "none",
+      "service_user": "nova",
       "glance_instance": "none",
       "libvirt_type": "kvm",
       "verbose": true,

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -13,6 +13,8 @@
           "required": true,
           "mapping": {
             "keystone_instance": { "type": "str", "required": true },
+            "service_user": { "type": "str", "required": true },
+            "service_password": { "type": "str" },
             "glance_instance": { "type": "str", "required": true },
             "libvirt_type": { "type": "str", "required": true },
             "verbose": { "type": "bool", "required": true },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -42,6 +42,8 @@ locale_additions:
           attributes: Attributes
           mysql_instance: MySQL
           keystone_instance: Keystone
+          service_user: Keystone Service User
+          service_password: Keystone Service Password
           glance_instance: Glance
           verbose: Verbose
           dhcp_enabled: DHCP Enabled

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -76,6 +76,7 @@ class NovaService < ServiceObject
     rescue
       @logger.info("Nova create_proposal: no keystone found")
     end
+    base["attributes"]["nova"]["service_password"] = '%012d' % rand(1e12)
 
     base["attributes"]["nova"]["glance_instance"] = ""
     begin

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -11,6 +11,12 @@
       %label{ :for => :keystone_instance }= t('.keystone_instance')
       = instance_selector("keystone", :keystone_instance, "keystone_instance", @proposal)
     %p
+      %label{ :for => :service_user }= t('.service_user')
+      %input#service_user{:type => "text", :name => "service_user", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["service_user"], :onchange => "update_value('service_user','service_user', 'string')"}
+    %p
+      %label{ :for => :service_password }= t('.service_password')
+      %input#service_password{:type => "text", :name => "service_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["service_password"], :onchange => "update_value('service_password','service_password', 'string')"}
+    %p
       %label{ :for => :glance_instance }= t('.glance_instance')
       = instance_selector("glance", :glance_instance, "glance_instance", @proposal)
     %p


### PR DESCRIPTION
 chef/cookbooks/nova/attributes/default.rb          |    2 ++
 chef/cookbooks/nova/recipes/api.rb                 |    4 ++--
 chef/cookbooks/nova/recipes/volume.rb              |    4 ++--
 chef/data_bags/crowbar/bc-template-nova.json       |    1 +
 chef/data_bags/crowbar/bc-template-nova.schema     |    2 ++
 crowbar.yml                                        |    2 ++
 crowbar_framework/app/models/nova_service.rb       |    1 +
 .../views/barclamp/nova/_edit_attributes.html.haml |    6 ++++++
 8 files changed, 18 insertions(+), 4 deletions(-)
