### PR TITLE
Don't restart services immediately

### DIFF
--- a/chef/cookbooks/nova/definitions/nova_package.rb
+++ b/chef/cookbooks/nova/definitions/nova_package.rb
@@ -29,7 +29,7 @@ define :nova_package do
     end
     supports :status => true, :restart => true
     action [:enable, :start]
-    subscribes :restart, resources(:template => "/etc/nova/nova.conf"), :immediately
+    subscribes :restart, resources(:template => "/etc/nova/nova.conf")
   end
 
 end


### PR DESCRIPTION
This might lead to failures as a restart might be attempted before the actual
package is installed. (E.g. nova::config updates nova.conf and triggers a
restart of nova-api before the -api package is installed)
