### PR TITLE
Fix missing / in file name for recipe in nova [1/2]

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -28,7 +28,7 @@ nova_package("compute")
 # These two files are to handle: https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/996840
 # This is a hack until that gets fixed.
 # 
-cookbook_file "usr/lib/python2.7/dist-packages/nova/virt/libvirt/connection.py" do
+cookbook_file "/usr/lib/python2.7/dist-packages/nova/virt/libvirt/connection.py" do
   user "root"
   group "root"
   mode "0755"


### PR DESCRIPTION
 chef/cookbooks/nova/recipes/compute.rb |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
