### PR TITLE
Update Fred to fix Nova when using QEMU based virt. [1/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -78,6 +78,9 @@ debs:
     repos:
       - deb http://ops.rcb.me/packages oneiric diablo-final
   ubuntu-12.04:
+    repos:
+      # Added to fix some libvirt errors using qemu with essex on 12.04
+      - deb http://ppa.launchpad.net/ubuntu-virt/ppa/ubuntu precise main 
     pkgs:
       - tgt
       - novnc


### PR DESCRIPTION
This adds the ubuntu-virt PPA as the source of our QEMU packages for Nova.

 crowbar.yml |    3 +++
 1 file changed, 3 insertions(+)
