### PR TITLE
Fix up Nova barclamp to pull in the ubuntu-virt repo. [1/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -78,6 +78,9 @@ debs:
     repos:
       - deb http://ops.rcb.me/packages oneiric diablo-final
   ubuntu-12.04:
+    repos:
+      # Added to fix some libvirt errors using qemu with essex on 12.04
+      - deb http://ppa.launchpad.net/ubuntu-virt/ppa/ubuntu precise main 
     pkgs:
       - tgt
       - novnc


### PR DESCRIPTION
See title.

This also adds a to de-URLencode cached file names, which was causing nginx
to break in certian rare occasions.

 crowbar.yml |    3 +++
 1 file changed, 3 insertions(+)
