### PR TITLE
Re-factor out inialize methods as it caused layout to fail in rails3 [5/11]

### DIFF
--- a/crowbar_framework/app/controllers/nova_controller.rb
+++ b/crowbar_framework/app/controllers/nova_controller.rb
@@ -14,9 +14,13 @@
 # 
 
 class NovaController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = NovaService.new logger
   end
+
+  private :set_service_object
   
   def nodes
     disk_list = {}


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/nova_controller.rb             |   68 ++++++++++---------
 1 files changed, 36 insertions(+), 32 deletions(-)
