### PR TITLE
Add UEFI support to fredwilma [1/4]

### DIFF
--- a/chef/cookbooks/nova/templates/default/openrc.erb
+++ b/chef/cookbooks/nova/templates/default/openrc.erb
@@ -1,21 +1,11 @@
-# NOVA ENV VARIABLES
-export NOVA_USERNAME=<%= @admin_username %>
-export NOVA_PASSWORD=<%= @admin_password %>
-export NOVA_PROJECT_ID=<%= @default_tenant %>
-export NOVA_API_KEY=${NOVA_PASSWORD}
-export NOVA_URL=http://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/v2.0/
-export NOVA_VERSION=1.1
-export NOVA_REGION_NAME=RegionOne
-
-# COMMON ENV VARIABLES
-export OS_USERNAME=${NOVA_USERNAME}
-export OS_PASSWORD=${NOVA_PASSWORD}
-export OS_TENANT_NAME=${NOVA_PROJECT_ID}
-export OS_AUTH_TENANT=${NOVA_PROJECT_ID}
-export OS_AUTH_URL=${NOVA_URL}
+# OPENSTACK ENV VARIABLES
+export OS_USERNAME=<%= @admin_username %>
+export OS_PASSWORD=<%= @admin_password %>
+export OS_TENANT_NAME=<%= @default_tenant %>
+export OS_AUTH_URL=http://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/v2.0/
 export OS_AUTH_STRATEGY=keystone
 
 # EUCA2OOLs ENV VARIABLES
-export EC2_ACCESS_KEY=${NOVA_USERNAME}
-export EC2_SECRET_KEY=${NOVA_PASSWORD}
+export EC2_ACCESS_KEY=${OS_USERNAME}
+export EC2_SECRET_KEY=${OS_PASSWORD}
 export EC2_URL=http://<%= @nova_api_ip_address %>:8773/services/Cloud


### PR DESCRIPTION
This pull request series adds support for nodes running in UEFI mode.
- We no longer rename nodes.  Some of the other UEFI related changes
  caused the node rename bugs to trigger more often than I wanted.
- Kickstarts, seeds, autoyasts, pxelinux config files, and elilo
  config files are configured on a per-node basis instead of a
  per-state basis.  This lets us be a little more flexible in how
  nodes are deployed.  UEFI needs this to handle some boot-related
  issues on redhat.
- Sledgehammer has been updated to include UEFI handling code.

Currently UEFI for Ubuntu on PowerEdge R 12th gen servers will not
work due to bad interactions between grub2 and the BIOS.  Redhat
(i.e. grub 1) works normally on PE-R and PE-C gear.

 chef/cookbooks/nova/templates/default/openrc.erb |   24 +++++++---------------
 1 file changed, 7 insertions(+), 17 deletions(-)
