### PR TITLE
Add os_support stanzas to selected barclamps. [12/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -27,7 +27,9 @@ barclamp:
     - keystone
     - nova_dashboard
   member:
-    - openstack 
+    - openstack
+  os_support:
+    - ubuntu-12.04
 
 crowbar:
   layout: 2


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |    4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
