### PR TITLE
Epic rename of CMDB to Jig [6/6]

### DIFF
--- a/crowbar_framework/app/controllers/nova_controller.rb
+++ b/crowbar_framework/app/controllers/nova_controller.rb
@@ -18,7 +18,7 @@ class NovaController < BarclampController
     disk_list = {}
     name = params[:id] || params[:name]
     node = Node.find_by_name(name)
-    node.cmdb_disks.each do | disk, data |
+    node.jig_disks.each do | disk, data |
       disk_list[disk] = data["size"] if data["usage"] == "Storage"
     end
     Rails.logger.info "disk list #{disk_list.inspect}"


### PR DESCRIPTION
CMDB as a name is confusing and does not fit with our tool-related
naming scheme.  Jig, on the other hand, is an awesome fit for what
CMDB does and it fits the naming scheme.

 .../app/controllers/nova_controller.rb             |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 902f781dd496ff9c1ed7cfa95126b038e665e7c9

Crowbar-Release: development
