### PR TITLE
Get Pebbles to be able to deploy Nova and spin up vms. [2/6]

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -38,44 +38,6 @@ package "mysql-client"
 
 nova_package("compute")
 
-#
-# These two files are to handle: https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/996840
-# This is a hack until that gets fixed.
-# 
-unless node[:nova][:use_gitrepo]
-  cookbook_file "/usr/lib/python2.7/dist-packages/nova/virt/libvirt/connection.py" do
-    user "root"
-    group "root"
-    mode "0755"
-    source "connection.py"
-  end
-  
-  ["/usr/lib/python2.7/dist-packages/nova/common/rootwrap/compute.py", "/usr/lib/python2.7/dist-packages/nova/rootwrap/compute.py"].each do |path|
-    cookbook_file "#{path}" do
-      user "root"
-      group "root"
-      mode "0755"
-      source "compute.py"
-      ignore_failure true
-    end
-  end
-
-  ## @@AA- perf. add io=native when mounting volumes. disable memory balooning.
-  cookbook_file "/usr/lib/python2.7/dist-packages/nova/virt/libvirt/volume.py" do
-    user "root"
-    group "root"
-    mode "0755"
-    source "volume.py"
-  end
-  cookbook_file "/usr/lib/python2.7/dist-packages/nova/virt/libvirt.xml.template" do 
-    user "root"
-    group "root"
-    mode "0755"
-    source "libvirt.xml.template"
-  end
-
-end  
-
 # ha_enabled activates Nova High Availability (HA) networking.
 # The nova "network" and "api" recipes need to be included on the compute nodes and
 # we must specify the --multi_host=T switch on "nova-manage network create".     

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -279,14 +279,12 @@ if node[:nova][:networking_backend]=="quantum"
   execute "add_route_for_metadata_service" do
     command "ip ro del #{node[:nova][:network][:fixed_range]} ; ip ro add #{node[:nova][:network][:fixed_range]} via #{quantum_server[:quantum][:network][:fixed_router]}"
     not_if "ip ro get #{node[:nova][:network][:fixed_range]} | grep -q 'via #{quantum_server[:quantum][:network][:fixed_router]}'"
-    ignore_failure true
   end
   if per_tenant_vlan
     quantum_server[:quantum][:network][:private_networks].each do |net|
       execute "add_route_for_network_#{net}" do
         command "ip ro replace #{net} via #{quantum_server[:quantum][:network][:fixed_router]}"
         not_if "ip ro get #{net} | grep -q 'via #{quantum_server[:quantum][:network][:fixed_router]}'"
-        ignore_failure true
       end
     end
   end

--- a/chef/cookbooks/nova/recipes/scheduler.rb
+++ b/chef/cookbooks/nova/recipes/scheduler.rb
@@ -20,3 +20,4 @@
 include_recipe "nova::config"
 
 nova_package("scheduler")
+nova_package("conductor")

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -129,3 +129,8 @@ volume_driver=nova.volume.eqlx.DellEQLSanISCSIDriver
 enabled_apis=ec2,osapi_compute,metadata
 volume_api_class=nova.volume.cinder.API
 <% end -%>
+
+# This needs to be conditionalized at some point, maybe.
+[conductor]
+use_local=false
+

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -139,6 +139,7 @@ debs:
     - nova-volume
     - nova-scheduler
     - nova-doc
+    - nova-conductor
     - nova-ajax-console-proxy
     - python-eventlet
     - bzr

--- a/smoketest/00-deploy-nova-vm.test
+++ b/smoketest/00-deploy-nova-vm.test
@@ -15,13 +15,12 @@
 
 die() { res=$1; shift; echo "$@"; exit $res; }
 
-nova_do() {
-    # $1 = address of nova controller
-    # $@ = command to run as the nova user.
-    local address="$1" 
-    shift
-    [[ $1 ]] || return 1
-    run_on "$address" sudo -u nova -i "$@"
+nova() {
+    command nova --os-auth-url "http://$keystone_ip:5000/v2.0" \
+        --os-username "$nova_user" \
+        --os-password "$nova_pass" \
+        --os-tenant-name service \
+        "$@"
 }
 
 echo "Deploying Nova VMs."
@@ -32,95 +31,64 @@ if ! [[ $nova_ip ]]; then
     exit 1
 fi
 echo "Controller at $nova_ip. Verifying nova services..."
-echo "Rest of smoketest is not functional.  Exiting."
 
-exit 0
+echo "Finding keystone..."
+keystone_ip=$(knife_node_find 'roles:keystone-server' IP)
+if [[ ! $keystone_ip ]]; then
+    die 1 "Cannot find Keystone"
+fi
+
+sudo apt-get install -y python-novaclient
+
+prop_file="$LOGDIR/nova-proposal.json"
+
+crowbar nova proposal show smoketest >"$prop_file"
+
+nova_user=$(grep service_user $prop_file | sed 's/[:,"]//g' | awk '{print $2}')
+nova_pass=$(grep service_password $prop_file | sed 's/[:,"]//g' | awk '{print $2}')
+[[ $nova_user && $nova_pass ]] || die 1 "nova_user: $nova_user | nova_pass: $nova_pass"
 
 while read node_type node zone node_enabled node_status rest; do
     case $node_type in
-	nova-network) [[ $node_enabled = enabled && \
-	    $node_status = ':-)' ]] && nova_network=true;;
-	nova-compute) [[ $node_enabled = enabled && \
-	    $node_status = ':-)' ]] && nova_compute=true;;
-	nova-scheduler) [[ $node_enabled = enabled && \
-	    $node_status = ':-)' ]] && nova_scheduler=true;;
+        nova-compute) [[ $node_enabled = enabled && \
+            $node_status = 'up' ]] && nova_compute=true;;
+        nova-scheduler) [[ $node_enabled = enabled && \
+            $node_status = 'up' ]] && nova_scheduler=true;;
     esac
-done < <(nova_do "$nova_ip" nova-manage service list |tee \
+done < <(nova service-list |tr -d '|' |tee \
     "$LOGDIR/nova-services.status")
-if ! [[ $nova_network && $nova_compute && $nova_scheduler ]]; then
+if ! [[ $nova_compute && $nova_scheduler ]]; then
     echo "Nova services do not report as healthy!"
     exit 1
 fi
 
-echo "Nova services healthy. Finding test image to launch..."
 test_image=''
-ami_re='(ami-[0-9]+)'
-
-###
-# Things after here are broken.
-###
+image_re='([-0-9a-f]+) \| ([^ ]+-image) | ACTIVE'
 
 while read line;do
-    [[ $line =~ $ami_re ]] || continue
-    img_id="${BASH_REMATCH[1]}"
-    [[ $line =~ available && $line =~ public ]] || continue
-    test_image=$img_id
+    [[ $line =~ $image_re ]] || continue
+    test_image="${BASH_REMATCH[1]}"
     break
-done < <(nova_do "$nova_ip" euca-describe-images |tee \
+done < <(nova image-list |tee \
     "$LOGDIR/nova-images.status")
 if [[ ! $test_image ]]; then
     echo "Could not find a test image to run on Nova"
     exit 1
 fi
 
-echo "Launching $test_image..." 
-nova_do "$nova_ip" euca-run-instances "$test_image" -k mykey -t m1.tiny |tee \
-    "$LOGDIR/nova-run-instance.status"
-tries=0
-img_addr=''
+echo "Launching $test_image..."
+nova boot --poll --image "$test_image" --flavor 1 smoketest-1 | tee "$LOGDIR/nova-run-instance.status"
 
-while ((tries++ < 30)); do
-    while read ltype l_id img_id img_addr1 img_addr2 img_status rest; do
-	[[ $img_id = $test_image ]] || continue
-	[[ $img_status =~ fail ]] && {
-	    echo "Nova reports that $test_image failed to deploy"
-	    cat "$LOGDIR/nova-running-instances.$tries.log"
-	    exit 1
-	}
-	[[ $img_id = $test_image && $img_status = running ]] || continue
-	img_addr=${img_addr1}
-    done < <(nova_do "$nova_ip" euca-describe-instances | \
-	tee "$LOGDIR/nova-running-instances.$tries.log")
-    cat "$LOGDIR/nova-running-instances.$tries.log"
-    [[ $img_addr ]] && break
-    sleep 10
-done
-if [[ ! $img_addr ]]; then
-    echo "$test_image failed to deploy after ${tries}0 seconds!"
-    exit 1
-fi	
-echo "Launched. Testing network connectivity..."
-tries=0
-while ! nova_do "$nova_ip" ping -n -c 1 "$img_addr" >> "$LOGDIR/nova-ping-$img_addr.log"; do
-    if ((tries++ > 60)) ; then
-      cat "$LOGDIR/nova-ping-$img_addr.log"
-      echo "Could not ping $img_addr from $nova_ip"
-      exit 1
-    fi
-done
-echo "Could ping deployed image."
-tries=0
+sleep 10
 
-## The SSH test is known to not work right now.
-# Leave it enabled, but do not fail the smoketest if it fails.
-while ! nova_do "$nova_ip" ssh -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -i /var/lib/nova/mykey.priv ubuntu@"$img_addr" date >> "$LOGDIR/nova-ssh-$img_addr.log" ; do
-    if ((tries++ > 120)) ; then
-      cat "$LOGDIR/nova-ssh-$img_addr.log"
-      cat "$LOGDIR/nova-ssh-$img_addr.err"
-      echo "Could not ssh $img_addr from $nova_ip"
-      exit 0
-    fi
-done
+if nova show smoketest-1 |grep -q 'status.*ACTIVE'; then
+    echo "Test image launched."
+else
+    die 1 "Failed to launch test image!"
+fi
+
+# Need to test network connectivity here.
+
 
 echo "Nova VM deploy passed."
 exit 0


### PR DESCRIPTION
These pull request updates allow Nova and all its prerequisites to
deploy using their default proposals, and test that Nova is able to
spin up a VM.

We still need to have proper smoketests for Quantum and Cinder, and
the Nova smoketests need to include testing attaching and detaching
networks and volumes to vms.

 chef/cookbooks/nova/recipes/compute.rb             |   38 -------
 chef/cookbooks/nova/recipes/config.rb              |    2 -
 chef/cookbooks/nova/recipes/scheduler.rb           |    1 +
 .../cookbooks/nova/templates/default/nova.conf.erb |    5 +
 crowbar.yml                                        |    1 +
 smoketest/00-deploy-nova-vm.test                   |  120 +++++++-------------
 6 files changed, 51 insertions(+), 116 deletions(-)

Crowbar-Pull-ID: a0c8ce902ba2ff2b08a2b4fcf2938992f2e17f34

Crowbar-Release: pebbles
