### PR TITLE
Fixing description for OS barclamps [2/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -18,7 +18,7 @@
 barclamp:
   name: nova
   display: Nova
-  description: OpenStack Compute: Provision and manage large network of virtual machines
+  description: 'OpenStack Compute: Provision and manage large network of virtual machines'
   version: 0
   requires:
     - '@crowbar'


### PR DESCRIPTION
Chnaged description for swift, glance, tempest, nova_dashboard, cinder, quantum and nova to match ones in OS.
Decsriptions for all these components are no defined in crowbar.yml instead of scattered between chef/data_bags and yml.

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: b671718679ec72e1f12a8a35bc36e8d102d1772c

Crowbar-Release: pebbles
