### PR TITLE
Handle abandoning a nic when the network barclamp takes over a system. [1/4]

### DIFF
--- a/smoketest/00-deploy-nova-vm.test
+++ b/smoketest/00-deploy-nova-vm.test
@@ -114,23 +114,17 @@ nova keypair-add smoketest >"$sshkey"
 chmod 600 "$sshkey"
 ssh-add "$sshkey"
 
-for ((idx=0; idx<6; idx++)); do
-    instance_name="smoketest-$idx"
-    instances[$idx]=$instance_name
-    (
-        # Things to add here:
-        # SSH key injection
-        # Binding a volume with Cinder
-        echo "Launching $instance_name with $test_image"
-        nova boot --poll --image "$test_image" --flavor 1 \
-            --nic net-id=$fixed_net \
-            --security-groups smoketest \
-            --key-name smoketest \
-            "$instance_name" | tee "$LOGDIR/nova-$instance_name.status"
-    ) &
-    sleep 2
-done
-wait
+idx=0
+instance_name="smoketest-$idx"
+instances[$idx]=$instance_name
+# Things to add here:
+# Binding a volume with Cinder
+echo "Launching $instance_name with $test_image"
+nova boot --poll --image "$test_image" --flavor 1 \
+    --nic net-id=$fixed_net \
+    --security-groups smoketest \
+    --key-name smoketest \
+    "$instance_name" | tee "$LOGDIR/nova-$instance_name.status"
 declare -A fixed_ips
 for instance_name in "${instances[@]}"; do
     if nova show $instance_name |grep -q 'status.*ACTIVE'; then


### PR DESCRIPTION
The network barclamp now properly handles the scenario where we
abandon the interface we initially PXE booted and installed from, and
the default smoketest now tests that configuration.

 smoketest/00-deploy-nova-vm.test |   28 +++++++++++-----------------
 1 file changed, 11 insertions(+), 17 deletions(-)

Crowbar-Pull-ID: dd3666f0c95a7d5b43e788a8e2c8b5d2e1e2e7bd

Crowbar-Release: pebbles
