### PR TITLE
Removed nova network picks from nova proposal screen [1/1]

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -75,6 +75,7 @@ default[:nova][:network][:vlan_start] = 100
 default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"
 
+default[:nova][:volume][:use_cinder] = "true"
 default[:nova][:volume][:volume_name] = "nova-volumes"
 default[:nova][:volume][:type] = "local"
 default[:nova][:volume][:nova_raw_method] = "all"

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -48,7 +48,6 @@ locale_additions:
     barclamp:
       nova:
         edit_attributes: 
-          networking_backend: Backend for networking
           attributes: Attributes
           mysql_instance: MySQL
           rabbitmq_instance: RabbitMQ
@@ -58,17 +57,9 @@ locale_additions:
           glance_instance: Glance
           verbose: Verbose
           use_novnc: Use NoVNC (otherwise VPN-VNC)
-          dhcp_enabled: DHCP Enabled
-          ha_enabled: High Availability Enabled
-          tenant_vlans: Use Tenant Vlans
           libvirt_type: Hypervisor
-          network_header: Network Options
-          allow_same_net_traffic: Allow Same-Network Traffic
-          num_networks: Number of Networks
-          network_size: Network Size
-          volume_header: Volume Options
+          quantum_instance: Quantum
           cinder_instance: Cinder
-          use_cinder: Use Cinder
           volume_type: Type of Volume
           volume_name: Name of Volume
           volume_file_parameters: File-based Parameters

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -33,36 +33,9 @@
       %label{ :for => :libvirt_type }= t('.libvirt_type')
       = select_tag :libvirt_type, options_for_select([['kvm','kvm'], ['qemu', 'qemu']], @proposal.raw_data['attributes'][@proposal.barclamp]["libvirt_type"].to_s), :onchange => "update_value('libvirt_type', 'libvirt_type', 'string')"
     %p
-      %label{ :for => :network_header }= t('.network_header')
-    %div.container
-      %p
-        %label{ :for => :networking_backend }= t('.networking_backend')
-        = select_tag :networking_backend, options_for_select([['quantum','quantum'], ['nova-network', 'nova-network']], @proposal.raw_data['attributes'][@proposal.barclamp]["networking_backend"].to_s), :onchange => "update_value('networking_backend', 'networking_backend', 'string')"
-      %p
-        %label{ :for => :tenant_vlans }= t('.tenant_vlans')
-        = select_tag :tenant_vlans, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["tenant_vlans"].to_s), :onchange => "update_value('network/tenant_vlans', 'tenant_vlans', 'boolean')"
-      %p
-        %label{ :for => :dhcp_enabled }= t('.dhcp_enabled')
-        = select_tag :dhcp_enabled, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["dhcp_enabled"].to_s), :onchange => "update_value('network/dhcp_enabled', 'dhcp_enabled', 'boolean')"
-      %p
-        %label{ :for => :ha_enabled }= t('.ha_enabled')
-        = select_tag :ha_enabled, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["ha_enabled"].to_s), :onchange => "update_value('network/ha_enabled', 'ha_enabled', 'boolean')"
-      %p
-        %label{ :for => :allow_same_net_traffic }= t('.allow_same_net_traffic')
-        = select_tag :allow_same_net_traffic, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["allow_same_net_traffic"].to_s), :onchange => "update_value('network/allow_same_net_traffic', 'allow_same_net_traffic', 'boolean')"
-      %p
-        %label{ :for => :num_networks }= t('.num_networks')
-        %input#num_networks{:type => "text", :name => "num_networks", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["num_networks"], :onchange => "update_value('network/num_networks','num_networks', 'integer')"}
-      %p
-        %label{ :for => :network_size }= t('.network_size')
-        %input#network_size{:type => "text", :name => "network_size", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["network"]["network_size"], :onchange => "update_value('network/network_size','network_size', 'integer')"}
+      %label{ :for => :quantum_instance }= t('.quantum_instance')
+      = instance_selector("quantum", :quantum_instance, "quantum_instance", @proposal)
     %p
-      %label{ :for => :volume_header }= t('.volume_header')
-    %div.container
-      %p
-        %label{ :for => :use_cinder }= t('.use_cinder')
-        = select_tag :use_cinder, options_for_select([['true','true']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["use_cinder"].to_s), :onchange => "update_value('volume/use_cinder', 'use_cinder', 'boolean')"
-      %p
-        %label{ :for => :cinder_instance }= t('.cinder_instance')
-        = instance_selector("cinder", :cinder_instance, "cinder_instance", @proposal)
+      %label{ :for => :cinder_instance }= t('.cinder_instance')
+      = instance_selector("cinder", :cinder_instance, "cinder_instance", @proposal)
 


### PR DESCRIPTION
This pull request removes the nova network attributes from the create/edit nova proposal screen.
Also tweaked the Cinder pick to be just a proposal selector so that it follows the same pattern
as mySql, rabbitmq, etc.

 chef/cookbooks/nova/attributes/default.rb          |    1 +
 crowbar.yml                                        |   11 +-----
 .../views/barclamp/nova/_edit_attributes.html.haml |   35 +++-----------------
 3 files changed, 6 insertions(+), 41 deletions(-)

Crowbar-Pull-ID: 7ad219a85704f3375524e9ed8377fb55bcc2b494

Crowbar-Release: pebbles
