### PR TITLE
env_filter fix for quantum multiproposal support

### DIFF
--- a/chef/cookbooks/nova/recipes/quantum.rb
+++ b/chef/cookbooks/nova/recipes/quantum.rb
@@ -14,3 +14,7 @@
 #
 
 include_recipe "quantum::common_install"
+
+node.set[:cookbook] = cookbook_name
+include_recipe "quantum::common_install"
+node.delete(:cookbook)


### PR DESCRIPTION
#151 pull request re submission. Adding multiproposal functionality to a quantum barclamp, by means of correct env_filter statement.
