### PR TITLE
Nova Improvements

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -125,6 +125,7 @@ enable_zone_routing=true
 auth_strategy=keystone
 volume_api_class=nova.volume.cinder.API
 enabled_apis=ec2,osapi_compute,metadata
+cinder_catalog_info=volume:cinder:internalURL
 
 # This needs to be conditionalized at some point, maybe.
 [conductor]


### PR DESCRIPTION
This fix modifies "nova.conf.erb" template and enables nova to use internal network ip addresses for cinder service endpoints. This measure allows to prevent situation when cinder-volumes  attachment process stucking in "attaching" state due to public network issues.
