### PR TITLE
Add non-configurable attribute for http/https use in keystone [6/7]

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -41,6 +41,7 @@ end
 nova_package("api")
 
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["service"]["token"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"]
 keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
@@ -55,6 +56,7 @@ template "/etc/nova/api-paste.ini" do
   group "root"
   mode "0640"
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_ip_address => keystone_address,
     :keystone_admin_token => keystone_token,
     :keystone_service_port => keystone_service_port,
@@ -77,6 +79,7 @@ public_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "publ
 admin_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "admin").address
 
 keystone_register "nova api wakeup keystone" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -84,6 +87,7 @@ keystone_register "nova api wakeup keystone" do
 end
 
 keystone_register "register nova user" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -94,6 +98,7 @@ keystone_register "register nova user" do
 end
 
 keystone_register "give nova user access" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -104,6 +109,7 @@ keystone_register "give nova user access" do
 end
 
 keystone_register "register nova service" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -114,6 +120,7 @@ keystone_register "register nova service" do
 end
 
 keystone_register "register ec2 service" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -124,6 +131,7 @@ keystone_register "register ec2 service" do
 end
 
 keystone_register "register nova endpoint" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -138,6 +146,7 @@ keystone_register "register nova endpoint" do
 end
 
 keystone_register "register nova ec2 endpoint" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -238,6 +238,7 @@ else
 end
 
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["service"]["token"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"]
 keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
@@ -297,6 +298,7 @@ template "/etc/nova/nova.conf" do
             :quantum_service_user => quantum_service_user,
             :quantum_service_password => quantum_service_password,
             :keystone_service_tenant => keystone_service_tenant,
+            :keystone_protocol => keystone_protocol,
             :keystone_address => keystone_address,
             :keystone_admin_port => keystone_admin_port
             )

--- a/chef/cookbooks/nova/recipes/project.rb
+++ b/chef/cookbooks/nova/recipes/project.rb
@@ -103,6 +103,7 @@ else
 end
 
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["admin"]["token"] rescue nil
 admin_username = keystone["keystone"]["admin"]["username"] rescue nil
 admin_password = keystone["keystone"]["admin"]["password"] rescue nil
@@ -135,6 +136,7 @@ template "/root/.openrc" do
   group "root"
   mode 0600
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_ip_address => keystone_address,
     :keystone_service_port => keystone_service_port,
     :admin_username => admin_username,

--- a/chef/cookbooks/nova/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/nova/templates/default/api-paste.ini.erb
@@ -118,13 +118,13 @@ paste.filter_factory = nova.api.auth:NovaKeystoneContext.factory
 
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
-service_protocol = http
+service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_ip_address %>
 service_port = <%= @keystone_service_port %>
 auth_host = <%= @keystone_ip_address %>
 auth_port = <%= @keystone_admin_port %>
-auth_protocol = http
-auth_uri = http://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/
+auth_protocol = <%= @keystone_protocol %>
+auth_uri = <%= @keystone_protocol %>://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/
 admin_user = <%= @keystone_service_user %>
 admin_password = <%= @keystone_service_password %>
 admin_tenant_name = <%= @keystone_service_tenant %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -43,7 +43,7 @@ quantum_auth_strategy=keystone
 quantum_admin_tenant_name=<%= @keystone_service_tenant %>
 quantum_admin_username=<%= @quantum_service_user %>
 quantum_admin_password=<%= @quantum_service_password %>
-quantum_admin_auth_url=http://<%= @keystone_address %>:<%= @keystone_admin_port %>/v2.0
+quantum_admin_auth_url=<%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_admin_port %>/v2.0
 libvirt_ovs_bridge=br-int
 libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtHybridOVSBridgeDriver
 libvirt_vif_type=ethernet

--- a/chef/cookbooks/nova/templates/default/openrc.erb
+++ b/chef/cookbooks/nova/templates/default/openrc.erb
@@ -2,7 +2,7 @@
 export OS_USERNAME=<%= @admin_username %>
 export OS_PASSWORD=<%= @admin_password %>
 export OS_TENANT_NAME=<%= @default_tenant %>
-export OS_AUTH_URL=http://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/v2.0/
+export OS_AUTH_URL=<%= @keystone_protocol %>://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/v2.0/
 export OS_AUTH_STRATEGY=keystone
 
 # EUCA2OOLs ENV VARIABLES


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
