### PR TITLE
Enable quantum linuxbridge support for nova

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -262,6 +262,7 @@ if quantum_servers.length > 0
   else
     per_tenant_vlan=false
   end
+  quantum_networking_plugin = quantum_server[:quantum][:networking_plugin]
   quantum_networking_mode = quantum_server[:quantum][:networking_mode]
 else
   quantum_server_ip = nil
@@ -297,6 +298,7 @@ template "/etc/nova/nova.conf" do
             :quantum_server_port => quantum_server_port,
             :quantum_service_user => quantum_service_user,
             :quantum_service_password => quantum_service_password,
+            :quantum_networking_plugin => quantum_networking_plugin,
             :keystone_service_tenant => keystone_service_tenant,
             :keystone_protocol => keystone_protocol,
             :keystone_address => keystone_address,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -44,10 +44,15 @@ quantum_admin_tenant_name=<%= @keystone_service_tenant %>
 quantum_admin_username=<%= @quantum_service_user %>
 quantum_admin_password=<%= @quantum_service_password %>
 quantum_admin_auth_url=<%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_admin_port %>/v2.0
+<% if @quantum_networking_plugin == "openvswitch" -%>
 libvirt_ovs_bridge=br-int
 libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtHybridOVSBridgeDriver
-libvirt_vif_type=ethernet
 linuxnet_interface_driver=nova.network.linux_net.LinuxOVSInterfaceDriver
+<% elsif @quantum_networking_plugin == "linuxbridge" -%>
+libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtBridgeDriver
+linuxnet_interface_driver=nova.network.linux_net.LinuxBridgeInterfaceDriver
+<% end -%>
+libvirt_vif_type=ethernet
 security_group_api=quantum
 firewall_driver=nova.virt.firewall.NoopFirewallDriver
 service_quantum_metadata_proxy=True


### PR DESCRIPTION
When running nova with quantum on linuxbridge plugin nova compute should
be aware of it to create appropriate interfaces for vms. This patch
sets libvirt_vif_driver and linuxnet_interface_driver in nova.conf.

This patch requires https://github.com/crowbar/barclamp-quantum/pull/63/files to be merged before.
