### PR TITLE
Add SSL support for quantum [2/3]

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -259,8 +259,10 @@ quantum_servers = search(:node, "roles:quantum-server") || []
 if quantum_servers.length > 0
   quantum_server = quantum_servers[0]
   quantum_server = node if quantum_server.name == node.name
+  quantum_protocol = quantum_server[:quantum][:api][:protocol]
   quantum_server_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(quantum_server, "admin").address
   quantum_server_port = quantum_server[:quantum][:api][:service_port]
+  quantum_insecure = quantum_protocol == 'https' && quantum_server[:quantum][:ssl][:insecure]
   quantum_service_user = quantum_server[:quantum][:service_user]
   quantum_service_password = quantum_server[:quantum][:service_password]
   if quantum_server[:quantum][:networking_mode] != 'local'
@@ -299,8 +301,10 @@ template "/etc/nova/nova.conf" do
             :glance_server_ip => glance_server_ip,
             :glance_server_port => glance_server_port,
             :vncproxy_public_ip => vncproxy_public_ip,
+            :quantum_protocol => quantum_protocol,
             :quantum_server_ip => quantum_server_ip,
             :quantum_server_port => quantum_server_port,
+            :quantum_insecure => quantum_insecure,
             :quantum_service_user => quantum_service_user,
             :quantum_service_password => quantum_service_password,
             :keystone_service_tenant => keystone_service_tenant,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -38,7 +38,8 @@ api_rate_limit = False
 # Network settings
 default_floating_pool=floating
 network_api_class=nova.network.quantumv2.api.API
-quantum_url=http://<%= @quantum_server_ip %>:<%= @quantum_server_port %>
+quantum_url=<%= @quantum_protocol %>://<%= @quantum_server_ip %>:<%= @quantum_server_port %>
+quantum_api_insecure=<%= @quantum_insecure ? 'True' : 'False' %>
 quantum_auth_strategy=keystone
 quantum_admin_tenant_name=<%= @keystone_service_tenant %>
 quantum_admin_username=<%= @quantum_service_user %>


### PR DESCRIPTION
In very much the same way that we added SSL support to keystone, here's support in quantum.

Note that OpenStack requires two patches for this to work:
- https://github.com/openstack/quantum/commit/a4faa98b99c9ab50e8fdb299cc3f404d8144b3a9
- https://github.com/openstack/horizon/commit/66b0f369a7454cf5bd84ede9deba3a80f81c9bc0

Crowbar-Pull-ID: d968381d56565a8275f9c8acdb174d117bc97dce

Crowbar-Release: pebbles
