### PR TITLE
Register endpoints with public name and FQDN when possible

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -45,7 +45,7 @@ end
 
 nova_package("api")
 
-keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_host = keystone[:fqdn]
 keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["service"]["token"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"]
@@ -53,7 +53,7 @@ keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
 keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
 keystone_service_user = node["nova"]["service_user"]
 keystone_service_password = node["nova"]["service_password"]
-Chef::Log.info("Keystone server found at #{keystone_address}")
+Chef::Log.info("Keystone server found at #{keystone_host}")
 
 template "/etc/nova/api-paste.ini" do
   source "api-paste.ini.erb"
@@ -62,7 +62,7 @@ template "/etc/nova/api-paste.ini" do
   mode "0640"
   variables(
     :keystone_protocol => keystone_protocol,
-    :keystone_ip_address => keystone_address,
+    :keystone_host => keystone_host,
     :keystone_admin_token => keystone_token,
     :keystone_service_port => keystone_service_port,
     :keystone_service_tenant => keystone_service_tenant,
@@ -80,13 +80,23 @@ if apis.length > 0 and !node[:nova][:network][:ha_enabled]
 else
   api = node
 end
-public_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "public").address
-admin_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "admin").address
+admin_api_host = api[:fqdn]
+# For the public endpoint, we prefer the public name. If not set, then we
+# use the IP address except for SSL, where we always prefer a hostname
+# (for certificate validation).
+public_api_host = api[:crowbar][:public_name]
+if public_api_host.nil? or public_api_host.empty?
+  unless api[:nova][:ssl][:enabled]
+    public_api_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "public").address
+  else
+    public_api_host = 'public.'+api[:fqdn]
+  end
+end
 api_protocol = api[:nova][:ssl][:enabled] ? 'https' : 'http'
 
 keystone_register "nova api wakeup keystone" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   action :wakeup
@@ -94,7 +104,7 @@ end
 
 keystone_register "register nova user" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   user_name keystone_service_user
@@ -105,7 +115,7 @@ end
 
 keystone_register "give nova user access" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   user_name keystone_service_user
@@ -116,7 +126,7 @@ end
 
 keystone_register "register nova service" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   service_name "nova"
@@ -127,7 +137,7 @@ end
 
 keystone_register "register ec2 service" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   service_name "ec2"
@@ -138,14 +148,14 @@ end
 
 keystone_register "register nova endpoint" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   endpoint_service "nova"
   endpoint_region "RegionOne"
-  endpoint_publicURL "#{api_protocol}://#{public_api_ip}:8774/v2/$(tenant_id)s"
-  endpoint_adminURL "#{api_protocol}://#{admin_api_ip}:8774/v2/$(tenant_id)s"
-  endpoint_internalURL "#{api_protocol}://#{admin_api_ip}:8774/v2/$(tenant_id)s"
+  endpoint_publicURL "#{api_protocol}://#{public_api_host}:8774/v2/$(tenant_id)s"
+  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:8774/v2/$(tenant_id)s"
+  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:8774/v2/$(tenant_id)s"
 #  endpoint_global true
 #  endpoint_enabled true
   action :add_endpoint_template
@@ -153,14 +163,14 @@ end
 
 keystone_register "register nova ec2 endpoint" do
   protocol keystone_protocol
-  host keystone_address
+  host keystone_host
   port keystone_admin_port
   token keystone_token
   endpoint_service "ec2"
   endpoint_region "RegionOne"
-  endpoint_publicURL "#{api_protocol}://#{public_api_ip}:8773/services/Cloud"
-  endpoint_adminURL "#{api_protocol}://#{admin_api_ip}:8773/services/Admin"
-  endpoint_internalURL "#{api_protocol}://#{admin_api_ip}:8773/services/Cloud"
+  endpoint_publicURL "#{api_protocol}://#{public_api_host}:8773/services/Cloud"
+  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:8773/services/Admin"
+  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:8773/services/Cloud"
 #  endpoint_global true
 #  endpoint_enabled true
   action :add_endpoint_template

--- a/chef/cookbooks/nova/recipes/project.rb
+++ b/chef/cookbooks/nova/recipes/project.rb
@@ -102,14 +102,24 @@ else
   keystone = node
 end
 
-keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+# For the public endpoint, we prefer the public name. If not set, then we
+# use the IP address except for SSL, where we always prefer a hostname
+# (for certificate validation).
+public_keystone_host = keystone[:crowbar][:public_name]
+if public_keystone_host.nil? or public_keystone_host.empty?
+  unless keystone[:nova][:ssl][:enabled]
+    public_keystone_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "public").address
+  else
+    public_keystone_host = 'public.'+keystone[:fqdn]
+  end
+end
 keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["admin"]["token"] rescue nil
 admin_username = keystone["keystone"]["admin"]["username"] rescue nil
 admin_password = keystone["keystone"]["admin"]["password"] rescue nil
 default_tenant = keystone["keystone"]["default"]["tenant"] rescue nil
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
-Chef::Log.info("Keystone server found at #{keystone_address}")
+Chef::Log.info("Keystone server found at #{public_keystone_host}")
 
 apis = search(:node, "recipes:nova\\:\\:api#{env_filter}") || []
 if apis.length > 0 and !node[:nova][:network][:ha_enabled]
@@ -118,9 +128,19 @@ if apis.length > 0 and !node[:nova][:network][:ha_enabled]
 else
   api = node
 end
-admin_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "admin").address
-Chef::Log.info("Admin API server found at #{admin_api_ip}")
 api_protocol = api[:nova][:ssl][:enabled] ? 'https' : 'http'
+# For the public endpoint, we prefer the public name. If not set, then we
+# use the IP address except for SSL, where we always prefer a hostname
+# (for certificate validation).
+public_api_host = api[:crowbar][:public_name]
+if public_api_host.nil? or public_api_host.empty?
+  unless api[:nova][:ssl][:enabled]
+    public_api_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "public").address
+  else
+    public_api_host = 'public.'+api[:fqdn]
+  end
+end
+Chef::Log.info("API server found at #{public_api_host}")
 
 if not node[:nova][:use_gitrepo]
   # install python-glanceclient on controller, to be able to upload images
@@ -138,12 +158,12 @@ template "/root/.openrc" do
   mode 0600
   variables(
     :keystone_protocol => keystone_protocol,
-    :keystone_ip_address => keystone_address,
+    :keystone_host => public_keystone_host,
     :keystone_service_port => keystone_service_port,
     :admin_username => admin_username,
     :admin_password => admin_password,
     :default_tenant => default_tenant,
-    :nova_api_ip_address => admin_api_ip,
+    :nova_api_host => public_api_host,
     :nova_api_protocol => api_protocol
   )
 end

--- a/chef/cookbooks/nova/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/nova/templates/default/api-paste.ini.erb
@@ -119,12 +119,12 @@ paste.filter_factory = nova.api.auth:NovaKeystoneContext.factory
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 service_protocol = <%= @keystone_protocol %>
-service_host = <%= @keystone_ip_address %>
+service_host = <%= @keystone_host %>
 service_port = <%= @keystone_service_port %>
-auth_host = <%= @keystone_ip_address %>
+auth_host = <%= @keystone_host %>
 auth_port = <%= @keystone_admin_port %>
 auth_protocol = <%= @keystone_protocol %>
-auth_uri = <%= @keystone_protocol %>://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/
+auth_uri = <%= @keystone_protocol %>://<%= @keystone_host %>:<%= @keystone_service_port %>/
 admin_user = <%= @keystone_service_user %>
 admin_password = <%= @keystone_service_password %>
 admin_tenant_name = <%= @keystone_service_tenant %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -43,13 +43,13 @@ my_ip=<%= node[:nova][:my_ip] %>
 # Network settings
 default_floating_pool=floating
 network_api_class=nova.network.quantumv2.api.API
-quantum_url=<%= @quantum_protocol %>://<%= @quantum_server_ip %>:<%= @quantum_server_port %>
+quantum_url=<%= @quantum_protocol %>://<%= @quantum_server_host %>:<%= @quantum_server_port %>
 quantum_api_insecure=<%= @quantum_insecure ? 'True' : 'False' %>
 quantum_auth_strategy=keystone
 quantum_admin_tenant_name=<%= @keystone_service_tenant %>
 quantum_admin_username=<%= @quantum_service_user %>
 quantum_admin_password=<%= @quantum_service_password %>
-quantum_admin_auth_url=<%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_admin_port %>/v2.0
+quantum_admin_auth_url=<%= @keystone_protocol %>://<%= @keystone_host %>:<%= @keystone_admin_port %>/v2.0
 <% if @quantum_networking_plugin == "openvswitch" -%>
 libvirt_ovs_bridge=br-int
 libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtHybridOVSBridgeDriver
@@ -100,9 +100,9 @@ flat_injected=True
 <% end -%>
 
 # GLANCE
-<% unless @glance_server_ip.nil? -%>
+<% unless @glance_server_host.nil? -%>
 image_service=nova.image.glance.GlanceImageService
-glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_ip %>:<%= @glance_server_port %>
+glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_host %>:<%= @glance_server_port %>
 glance_api_insecure=<%= @glance_server_insecure ? 'True' : 'False' %>
 <% end -%>
 
@@ -132,18 +132,18 @@ notification_driver=nova.openstack.common.notifier.rpc_notifier
 notification_driver=ceilometer.compute.nova_notifier
 
 # VNCPROXY
-<% unless @vncproxy_public_ip.nil? -%>
+<% unless @vncproxy_public_host.nil? -%>
 <% if node[:nova][:use_novnc] -%>
 <% if node[:roles].include?("nova-multi-controller") -%>
 novncproxy_host=0.0.0.0
 novncproxy_port=6080
 <% end -%>
-novncproxy_base_url=<%= @vncproxy_ssl_enabled ? "https" : "http" %>://<%= @vncproxy_public_ip %>:6080/vnc_auto.html
+novncproxy_base_url=<%= @vncproxy_ssl_enabled ? "https" : "http" %>://<%= @vncproxy_public_host %>:6080/vnc_auto.html
 ssl_only=<%= @vncproxy_ssl_enabled ? "True" : "False" %>
 cert=<%= @vncproxy_cert_file %>
 key=<%= @vncproxy_key_file %>
 <% else -%>
-xvpvncproxy_base_url=http://<%= @vncproxy_public_ip %>:6081/console
+xvpvncproxy_base_url=http://<%= @vncproxy_public_host %>:6081/console
 <% end -%>
 <% end -%>
 vncserver_listen=0.0.0.0

--- a/chef/cookbooks/nova/templates/default/openrc.erb
+++ b/chef/cookbooks/nova/templates/default/openrc.erb
@@ -2,10 +2,10 @@
 export OS_USERNAME=<%= @admin_username %>
 export OS_PASSWORD=<%= @admin_password %>
 export OS_TENANT_NAME=<%= @default_tenant %>
-export OS_AUTH_URL=<%= @keystone_protocol %>://<%= @keystone_ip_address %>:<%= @keystone_service_port %>/v2.0/
+export OS_AUTH_URL=<%= @keystone_protocol %>://<%= @keystone_host %>:<%= @keystone_service_port %>/v2.0/
 export OS_AUTH_STRATEGY=keystone
 
 # EUCA2OOLs ENV VARIABLES
 export EC2_ACCESS_KEY=${OS_USERNAME}
 export EC2_SECRET_KEY=${OS_PASSWORD}
-export EC2_URL=<%= @nova_api_protocol %>://<%= @nova_api_ip_address %>:8773/services/Cloud
+export EC2_URL=<%= @nova_api_protocol %>://<%= @nova_api_host %>:8773/services/Cloud


### PR DESCRIPTION
When using SSL, the common name field in the certificates is checked,
and using IP addresses won't work with that.

Internally to the OpenStack setup, it is always fine to use the FQDN
from the node, so we use this in the internal and admin URLs of the
endpoints.

For the public URL, we prefer to use the public name if it is set. If it
it not set, then we use the public FQDN only if SSL is enabled;
otherwise, we prefer the IP address (like before) because we're not 100%
sure that the administrator will have completed a proper DNS setup where
the public FQDN generated by Crowbar will be announced externally.
