### PR TITLE
Always set ec2_* and my_ip options in nova.conf

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -32,8 +32,13 @@ cpu_allocation_ratio=<%= node[:nova][:scheduler][:cpu_allocation_ratio] %>
 osapi_compute_extension=nova.api.openstack.compute.contrib.standard_extensions
 api_rate_limit = False
 
+# EC2
+ec2_scheme=<%= @ssl_enabled ? "https" : "http" %>
+ec2_host=<%= @ec2_host %>
+ec2_dmz_host=<%= @ec2_dmz_host %>
 
 # NETWORK
+my_ip=<%= node[:nova][:my_ip] %>
 <% if node[:nova][:networking_backend]=="quantum" -%>
 # Network settings
 default_floating_pool=floating
@@ -61,12 +66,7 @@ service_quantum_metadata_proxy=True
 # and we should be using whatever it generates.
 quantum_metadata_proxy_shared_secret=Secret
 <% else -%>
-my_ip=<%= node[:nova][:my_ip] %>
 allow_same_net_traffic=<%= node[:nova][:network][:allow_same_net_traffic] ? "True" : "False" %>
-ec2_scheme=<%= @ssl_enabled ? "https" : "http" %>
-ec2_host=<%= @ec2_host %>
-ec2_dmz_host=<%= @ec2_dmz_host %>
-osapi_host=<%= @ec2_host %>
 fixed_range=<%= node[:nova][:network][:fixed_range] %>
 floating_range=<%= node[:nova][:network][:floating_range] %>
 <% if node[:nova][:network][:public_interface] -%>


### PR DESCRIPTION
They were only set when quantum is not used, but that makes no sense.

Also osapi_host doesn't exist anymore.
