### PR TITLE
Restrict metadata service to only listen on admin IP address

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -84,6 +84,7 @@ if apis.length > 0 and !node[:nova][:network][:ha_enabled]
 else
   api = node
 end
+admin_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(api, "admin").address
 admin_api_host = api[:fqdn]
 # For the public endpoint, we prefer the public name. If not set, then we
 # use the IP address except for SSL, where we always prefer a hostname
@@ -363,6 +364,7 @@ template "/etc/nova/nova.conf" do
             :glance_server_host => glance_server_host,
             :glance_server_port => glance_server_port,
             :glance_server_insecure => glance_server_insecure,
+            :metadata_bind_address => admin_api_ip,
             :vncproxy_public_host => vncproxy_public_host,
             :vncproxy_ssl_enabled => api[:nova][:novnc][:ssl][:enabled],
             :vncproxy_cert_file => api_novnc_ssl_certfile,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -32,6 +32,9 @@ cpu_allocation_ratio=<%= node[:nova][:scheduler][:cpu_allocation_ratio] %>
 osapi_compute_extension=nova.api.openstack.compute.contrib.standard_extensions
 api_rate_limit = False
 
+# METADATA
+metadata_listen = <%= @metadata_bind_address %>
+
 # EC2
 ec2_scheme=<%= @ssl_enabled ? "https" : "http" %>
 ec2_host=<%= @ec2_host %>
@@ -160,7 +163,7 @@ enabled_apis=ec2,osapi_compute,metadata
 cinder_catalog_info=volume:cinder:internalURL
 
 # a list of APIs with enabled SSL (list value)
-enabled_ssl_apis = <%= @ssl_enabled ? "ec2,osapi_compute,metadata" : "" %>
+enabled_ssl_apis = <%= @ssl_enabled ? "ec2,osapi_compute" : "" %>
 
 # SSL certificate of API server (string value)
 ssl_cert_file = <%= @ssl_cert_file %>


### PR DESCRIPTION
This service is dedicated to instance guests, and is proxied there. It
should not be reachable from the external network.

Also, do not make it use SSL as quantum currently only supports metadata
running on http.

Note that this pull request depends on https://github.com/crowbar/barclamp-nova/pull/178
