### PR TITLE
Set cinder_api_insecure if cinder certificate is not secure

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -252,7 +252,13 @@ keystone_service_user = node[:nova][:service_user]
 keystone_service_password = node[:nova][:service_password]
 Chef::Log.info("Keystone server found at #{keystone_address}")
 
-
+cinder_servers = search(:node, "roles:cinder-controller") || []
+if cinder_servers.length > 0
+  cinder_server = cinder_servers[0]
+  cinder_insecure = cinder_server[:cinder][:api][:protocol] == 'https' && cinder[:cinder][:ssl][:insecure]
+else
+  cinder_insecure = false
+end
 
 quantum_servers = search(:node, "roles:quantum-server") || []
 if quantum_servers.length > 0
@@ -352,6 +358,7 @@ template "/etc/nova/nova.conf" do
             :keystone_protocol => keystone_protocol,
             :keystone_address => keystone_address,
             :keystone_admin_port => keystone_admin_port,
+            :cinder_insecure => cinder_insecure,
             :ssl_enabled => api[:nova][:ssl][:enabled],
             :ssl_cert_file => api[:nova][:ssl][:certfile],
             :ssl_key_file => api[:nova][:ssl][:keyfile],

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -157,6 +157,7 @@ auth_strategy=keystone
 volume_api_class=nova.volume.cinder.API
 enabled_apis=ec2,osapi_compute,metadata
 cinder_catalog_info=volume:cinder:internalURL
+cinder_api_insecure=<%= @cinder_insecure ? 'True' : 'False' %>
 
 # a list of APIs with enabled SSL (list value)
 enabled_ssl_apis = <%= @ssl_enabled ? "ec2,osapi_compute,metadata" : "" %>


### PR DESCRIPTION
This depends on https://github.com/crowbar/barclamp-glance/issues/105
