### PR TITLE
Install ceilometerclient to fix nova notfication_driver errors

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -33,6 +33,9 @@ unless node[:nova][:use_gitrepo]
     end
     action :install
   end
+
+  # nova.conf.erb has notification_driver=ceilometer.compute.nova_notifier, thus:
+  package "python-ceilometerclient"
 else
   pfs_and_install_deps "nova" do
     virtualenv venv_path

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -81,6 +81,7 @@
         "pip://python-quantumclient>=2.1",
         "pip://python-glanceclient>=0.5.0,<2",
         "pip://python-novaclient",
+        "pip://python-ceilometerclient",
         "pip://python-cinderclient",
         "pip://python-keystoneclient>=0.2.0",
         "pip://prettytable>=0.6,<0.8",


### PR DESCRIPTION
Fixes error messages like:

2013-07-11 10:07:19.256 ERROR nova.openstack.common.notifier.api [req-65c5c212-63d5-4376-b755-941bea66e828 526abc01f1f2485198c3341957c3c22f 4cd1601e28f44a2da9727a518ac1198b] Failed to load notifier ceilometer.co
mpute.nova_notifier. These notifications will not be sent.
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api Traceback (most recent call last):
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api   File "/usr/lib64/python2.6/site-packages/nova/openstack/common/notifier/api.py", line 169, in add_driver
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api     driver = importutils.import_module(notification_driver)
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api   File "/usr/lib64/python2.6/site-packages/nova/openstack/common/importutils.py", line 58, in import_module
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api     **import**(import_str)
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api ImportError: No module named ceilometer.compute.nova_notifier
2013-07-11 10:07:19.256 16087 TRACE nova.openstack.common.notifier.api
