### PR TITLE
DE1191 -- fix warnings in Nagios logs [2/2]

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -114,9 +114,9 @@ end
 vncproxy_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(vncproxy, "public").address
 Chef::Log.info("VNCProxy server at #{vncproxy_public_ip}")
 
-directory "/etc/nova/" do
+directory "/etc/nova" do
    mode 0755
-   action :nothing
+   action :create
 end
 
 cookbook_file "/etc/default/nova-common" do


### PR DESCRIPTION
Multi-nova-controller uses manage-nova command to monitor services. This
command relies on keystone for authenication.  The recipes for nova/nagios
will need to be updated to reflect these changes.  Since this is classified
as qa minor bug recommend pushing to mesa 1.7.

 chef/cookbooks/nova/recipes/config.rb |    5 +++++
 1 file changed, 5 insertions(+)

Crowbar-Pull-ID: 3db71170069a0d35fc2ebfd49f6acb971c481dc7

Crowbar-Release: mesa-1.6
