### PR TITLE
Stop installing python-keystone package

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -32,7 +32,6 @@ else
 end
 
 unless node[:nova][:use_gitrepo]
-  package "python-keystone"
   package "python-novaclient"
 else
   pfs_and_install_deps "keystone" do


### PR DESCRIPTION
This is not needed since we moved to using
keystoneclient.middleware.auth_token.
