### PR TITLE
Move setting /sys/* options to an external utility

### DIFF
--- a/chef/cookbooks/nova/files/default/crowbar-compute-set-sys-options-at-boot
+++ b/chef/cookbooks/nova/files/default/crowbar-compute-set-sys-options-at-boot
@@ -1,0 +1,4 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+@reboot root /usr/sbin/crowbar-compute-set-sys-options

--- a/chef/cookbooks/nova/templates/default/crowbar-compute-set-sys-options.erb
+++ b/chef/cookbooks/nova/templates/default/crowbar-compute-set-sys-options.erb
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if test -w /sys/kernel/mm/ksm/run; then
+  echo <%= @ksm_enabled %> > /sys/kernel/mm/ksm/run
+fi
+
+# Note: path to setting is OS dependent
+# redhat /sys/kernel/mm/redhat_transparent_hugepage/enabled
+# Below will work on both Ubuntu and SLES
+if test -w /sys/kernel/mm/transparent_hugepage/enabled; then
+  echo <%= @tranparent_hugepage_enabled %> > /sys/kernel/mm/transparent_hugepage/enabled
+fi
+
+if test -w /sys/kernel/mm/transparent_hugepage/defrag; then
+  echo <%= @tranparent_hugepage_defrag %> > /sys/kernel/mm/transparent_hugepage/defrag
+fi
+
+find /sys/block -type l -name 'sd*' -exec sh -c 'echo deadline > {}/queue/scheduler' \;


### PR DESCRIPTION
This allows us to have a cron job that will run on reboot, to make these
settings persistent accross reboots.
