### PR TITLE
Be more strict when editing /etc/libvirt/qemu.conf

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -120,8 +120,14 @@ if node.platform == "suse"
         rc.search_file_replace_line(/^ *group *=/, '#group = "root"')
       end
 
-      libvirt_restart_needed = true if rc.file_edited?
-      rc.write_file
+      if rc.file_edited?
+        # we compare the checksum to know if the file really changed because
+        # the regexp can update a line without changing it...
+        old_md5 = Digest::MD5.hexdigest(File.read('/etc/libvirt/qemu.conf'))
+        rc.write_file
+        new_md5 = Digest::MD5.hexdigest(File.read('/etc/libvirt/qemu.conf'))
+        libvirt_restart_needed = (old_md5 != new_md5)
+      end
     end
   end
 


### PR DESCRIPTION
We could match more lines than what we wanted.
