### PR TITLE
Add library search_env_filtered

### DIFF
--- a/chef/cookbooks/nova/libraries/search_env_filtered.rb
+++ b/chef/cookbooks/nova/libraries/search_env_filtered.rb
@@ -1,0 +1,24 @@
+class Chef
+  class Recipe
+    def search_env_filtered(type, query="*:*", sort='X_CHEF_id_CHEF_X asc', start=0, rows=100, &block)
+      # All cookbooks encode the barclamp name as the role name prefix, thus we can
+      # simply grab it from the query (e.g. BC 'keystone' for role 'keystone-server'):
+      barclamp = /^\w*:(\w*).*$/.match(query)[1]
+
+      # There are two conventions to filter by barclamp proposal:
+      #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]
+      #  2) Same cookbook: node[@cookbook_name][:config][:environment]
+      if barclamp == @cookbook_name
+        env = node[:nova][:config][:environment]
+      else
+        env = "#{barclamp}-config-#{node[@cookbook_name]["#{barclamp}_instance"]}"
+      end
+      filtered_query = "#{query} AND #{barclamp}_config_environment:#{env}"
+      if block
+        return search(type, filtered_query, sort, start, rows, &block)
+      else
+        return search(type, filtered_query, sort, start, rows)[0]
+      end
+    end
+  end
+end

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -22,8 +22,7 @@ include_recipe "nova::config"
 nova_path = "/opt/nova"
 venv_path = node[:nova][:use_virtualenv] ? "#{nova_path}/.venv" : nil
 
-env_filter = " AND keystone_config_environment:keystone-config-#{node[:nova][:keystone_instance]}"
-keystones = search(:node, "recipes:keystone\\:\\:server#{env_filter}") || []
+keystones = search_env_filtered(:node, "recipes:keystone\\:\\:server")
 if keystones.length > 0
   keystone = keystones[0]
   keystone = node if keystone.name == node.name
@@ -72,7 +71,7 @@ template "/etc/nova/api-paste.ini" do
   notifies :restart, resources(:service => "nova-api"), :immediately
 end
 
-apis = search(:node, "recipes:nova\\:\\:api#{env_filter}") || []
+apis = search_env_filtered(:node, "recipes:nova\\:\\:api")
 if apis.length > 0 and !node[:nova][:network][:ha_enabled]
   api = apis[0]
   api = node if api.name == node.name

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -45,8 +45,7 @@ end
 
 include_recipe "database::client"
 
-env_filter = " AND database_config_environment:database-config-#{node[:nova][:db][:database_instance]}"
-sqls = search(:node, "roles:database-server#{env_filter}") || []
+sqls = search_env_filtered(:node, "roles:database-server")
 if sqls.length > 0
   sql = sqls[0]
   sql = node if sql.name == node.name
@@ -62,8 +61,7 @@ database_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "a
 Chef::Log.info("database server found at #{database_address}")
 database_connection = "#{backend_name}://#{node[:nova][:db][:user]}:#{node[:nova][:db][:password]}@#{database_address}/#{node[:nova][:db][:database]}"
 
-env_filter = " AND rabbitmq_config_environment:rabbitmq-config-#{node[:nova][:rabbitmq_instance]}"
-rabbits = search(:node, "roles:rabbitmq-server#{env_filter}") || []
+rabbits = search_env_filtered(:node, "roles:rabbitmq-server")
 if rabbits.length > 0
   rabbit = rabbits[0]
   rabbit = node if rabbit.name == node.name
@@ -80,7 +78,7 @@ rabbit_settings = {
   :vhost => rabbit[:rabbitmq][:vhost]
 }
 
-apis = search(:node, "recipes:nova\\:\\:api#{env_filter}") || []
+apis = search_env_filtered(:node, "recipes:nova\\:\\:api")
 if apis.length > 0 and !node[:nova][:network][:ha_enabled]
   api = apis[0]
   api = node if api.name == node.name
@@ -102,7 +100,7 @@ if public_api_host.nil? or public_api_host.empty?
 end
 Chef::Log.info("Api server found at #{admin_api_host} #{public_api_host}")
 
-dns_servers = search(:node, "roles:dns-server") || []
+dns_servers = search_env_filtered(:node, "roles:dns-server")
 if dns_servers.length > 0
   dns_server = dns_servers[0]
   dns_server = node if dns_server.name == node.name
@@ -112,8 +110,7 @@ end
 dns_server_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(dns_server, "public").address
 Chef::Log.info("DNS server found at #{dns_server_public_ip}")
 
-env_filter = " AND glance_config_environment:glance-config-#{node[:nova][:glance_instance]}"
-glance_servers = search(:node, "roles:glance-server#{env_filter}") || []
+glance_servers = search_env_filtered(:node, "roles:glance-server")
 if glance_servers.length > 0
   glance_server = glance_servers[0]
   glance_server = node if glance_server.name == node.name
@@ -129,7 +126,7 @@ else
 end
 Chef::Log.info("Glance server at #{glance_server_host}")
 
-vncproxies = search(:node, "recipes:nova\\:\\:vncproxy#{env_filter}") || []
+vncproxies = search_env_filtered(:node, "recipes:nova\\:\\:vncproxy")
 if vncproxies.length > 0
   vncproxy = vncproxies[0]
   vncproxy = node if vncproxy.name == node.name
@@ -262,8 +259,7 @@ if node[:nova][:use_gitrepo]
   end
 end
 
-env_filter = " AND keystone_config_environment:keystone-config-#{node[:nova][:keystone_instance]}"
-keystones = search(:node, "recipes:keystone\\:\\:server#{env_filter}") || []
+keystones = search_env_filtered(:node, "recipes:keystone\\:\\:server")
 if keystones.length > 0
   keystone = keystones[0]
   keystone = node if keystone.name == node.name
@@ -289,7 +285,7 @@ else
   cinder_insecure = false
 end
 
-quantum_servers = search(:node, "roles:quantum-server") || []
+quantum_servers = search_env_filtered(:node, "roles:quantum-server")
 if quantum_servers.length > 0
   quantum_server = quantum_servers[0]
   quantum_server = node if quantum_server.name == node.name

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -24,8 +24,7 @@
 include_recipe "database::client"
 
 # find sql server
-env_filter = " AND database_config_environment:database-config-#{node[:nova][:db][:database_instance]}"
-sqls = search(:node, "roles:database-server#{env_filter}")
+sqls = search_env_filtered(:node, "roles:database-server")
 # if we found ourself, then use us.
 if sqls.length > 0
     sql = sqls[0]

--- a/chef/cookbooks/nova/recipes/monitor.rb
+++ b/chef/cookbooks/nova/recipes/monitor.rb
@@ -27,30 +27,25 @@ nova_scale = {
   :apis => []
 }
 
-env_filter = " AND nova_config_environment:#{node[:nova][:config][:environment]}" rescue nil
-if env_filter
-  search(:node, "roles:nova-single-machine #{env_filter}") do |n|
-    nova_scale[:computes] << n
-    nova_scale[:networks] << n
-    nova_scale[:schedulers] << n
-    nova_scale[:apis] << n
-  end
+search_env_filtered(:node, "roles:nova-single-machine") do |n|
+  nova_scale[:computes] << n
+  nova_scale[:networks] << n
+  nova_scale[:schedulers] << n
+  nova_scale[:apis] << n
+end
 
-  search(:node, "roles:nova-multi-controller #{env_filter}") do |n|
-    nova_scale[:networks] << n
-    nova_scale[:schedulers] << n
-    nova_scale[:apis] << n
-  end
+search_env_filtered(:node, "roles:nova-multi-controller") do |n|
+  nova_scale[:networks] << n
+  nova_scale[:schedulers] << n
+  nova_scale[:apis] << n
+end
 
-  search(:node, "roles:nova-multi-compute-kvm #{env_filter}") do |n|
-    nova_scale[:computes] << n
-  end
+search_env_filtered(:node, "roles:nova-multi-compute-kvm") do |n|
+  nova_scale[:computes] << n
+end
 
-   search(:node, "roles:nova-multi-compute-qemu #{env_filter}") do |n|
-    nova_scale[:computes] << n
-  end
-
-  # As other nova and swift roles come on-line we should add them here.
+search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
+  nova_scale[:computes] << n
 end
 
 if node["roles"].include?("nagios-client")    

--- a/chef/cookbooks/nova/recipes/project.rb
+++ b/chef/cookbooks/nova/recipes/project.rb
@@ -44,8 +44,7 @@ execute "nova-manage floating create --ip_range=#{node[:nova][:network][:floatin
 end
 
 unless node[:nova][:network][:tenant_vlans]
-  env_filter = " AND database_config_environment:database-config-#{node[:nova][:db][:database_instance]}"
-  db_server = search(:node, "roles:database-server#{env_filter}")[0]
+  db_server = search_env_filtered(:node, "roles:database-server")[0]
   db_server = node if db_server.name == node.name
   backend_name = Chef::Recipe::Database::Util.get_backend_name(db_server)
 
@@ -93,8 +92,7 @@ end
 end
 
 # Setup administrator credentials file
-env_filter = " AND keystone_config_environment:keystone-config-#{node[:nova][:keystone_instance]}"
-keystones = search(:node, "recipes:keystone\\:\\:server#{env_filter}") || []
+keystones = search_env_filtered(:node, "recipes:keystone\\:\\:server")
 if keystones.length > 0
   keystone = keystones[0]
   keystone = node if keystone.name == node.name
@@ -121,7 +119,7 @@ default_tenant = keystone["keystone"]["default"]["tenant"] rescue nil
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
 Chef::Log.info("Keystone server found at #{public_keystone_host}")
 
-apis = search(:node, "recipes:nova\\:\\:api#{env_filter}") || []
+apis = search_env_filtered(:node, "recipes:nova\\:\\:api")
 if apis.length > 0 and !node[:nova][:network][:ha_enabled]
   api = apis[0]
   api = node if api.name == node.name

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -3,6 +3,7 @@
   "description": "installs and configures the Openstack Nova component. It relies upon the network and glance barclamps for normal operation.",
   "attributes": {
     "nova": {
+      "database_instance": "none",
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
       "service_user": "nova",
@@ -109,7 +110,6 @@
 	"cpu_allocation_ratio": 16.0
       },
       "db": {
-        "database_instance": "none",
         "password": "",
         "user": "nova",
         "database": "nova"

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -12,6 +12,7 @@
           "type": "map", 
           "required": true,
           "mapping": {
+            "database_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
@@ -67,7 +68,6 @@
               "type": "map",
               "required": true,
               "mapping": {
-                "database_instance": { "type": "str", "required": true },
                 "password": { "type": "str", "required": true },
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -27,7 +27,7 @@ class NovaService < ServiceObject
 
   def proposal_dependencies(role)
     answer = []
-    answer << { "barclamp" => "database", "inst" => role.default_attributes["nova"]["db"]["database_instance"] }
+    answer << { "barclamp" => "database", "inst" => role.default_attributes["nova"]["database_instance"] }
     answer << { "barclamp" => "keystone", "inst" => role.default_attributes["nova"]["keystone_instance"] }
     answer << { "barclamp" => "glance", "inst" => role.default_attributes["nova"]["glance_instance"] }
     answer << { "barclamp" => "rabbitmq", "inst" => role.default_attributes["nova"]["rabbitmq_instance"] }
@@ -82,7 +82,7 @@ class NovaService < ServiceObject
       @logger.info("#{@bc_name} create_proposal: no git found")
     end
 
-    base["attributes"]["nova"]["db"]["database_instance"] = ""
+    base["attributes"]["nova"]["database_instance"] = ""
     begin
       databaseService = DatabaseService.new(@logger)
       dbs = databaseService.list_active[1]
@@ -93,13 +93,13 @@ class NovaService < ServiceObject
       if dbs.empty?
         @logger.info("Nova create_proposal: no database proposal found")
       else
-        base["attributes"]["nova"]["db"]["database_instance"] = dbs[0]
+        base["attributes"]["nova"]["database_instance"] = dbs[0]
       end
     rescue
       @logger.info("Nova create_proposal: no database found")
     end
 
-    if base["attributes"]["nova"]["db"]["database_instance"] == ""
+    if base["attributes"]["nova"]["database_instance"] == ""
       raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "database"))
     end
 

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -5,7 +5,7 @@
   %label{:for => "proposal_attributes"}= t('.attributes')
   = link_to t('raw'), proposal_barclamp_path(:id => @proposal.name, :controller => @proposal.barclamp, :dep_raw => @dep_raw, :attr_raw => true), :style => "float: right;"
   %div.container
-    = render_instance_selector("database", :database_instance, t('.database_instance'), "db/database_instance", @proposal)
+    = render_instance_selector("database", :database_instance, t('.database_instance'), "database_instance", @proposal)
     = render_instance_selector("rabbitmq", :rabbitmq_instance, t('.rabbitmq_instance'), "rabbitmq_instance", @proposal)
     = render_instance_selector("keystone", :keystone_instance, t('.keystone_instance'), "keystone_instance", @proposal)
     = render_instance_selector("glance", :glance_instance, t('.glance_instance'), "glance_instance", @proposal)


### PR DESCRIPTION
Provides a search that automatically applies an "env_filter", i.e. doing a search against the correct proposal. To make this work, nova/db/database_instance had to move to nova/database_instance (in line with _all_ other *_instance entries in JSON files).

As a nice side effect, most previously broken env_filter get fixed automatically. Before, some search() invocations re-(ab)used env_filters from previous searches for entirely different barclamps. This should help re-supporting multi-proposal in the future.

This approach should work for other barclamps too, but with Crowbar's current architecture, each would have to ship it's own copy of this library. A follow-up commit could move this to a more appropriate (shared) location.
