### PR TITLE
webui: Remove libvirt_type from UI that got added back by accident

### DIFF
--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -25,9 +25,6 @@
       = select_tag :use_novnc, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_novnc"].to_s), :onchange => "update_value('use_novnc', 'use_novnc', 'boolean')"
     = render 'barclamp/git/pfsdeps.html.haml'
     %p
-      %label{ :for => :libvirt_type }= t('.libvirt_type')
-      = select_tag :libvirt_type, options_for_select([['kvm','kvm'], ['qemu', 'qemu']], @proposal.raw_data['attributes'][@proposal.barclamp]["libvirt_type"].to_s), :onchange => "update_value('libvirt_type', 'libvirt_type', 'string')"
-    %p
       %label{ :for => :shared_instance_storage }= t('.shared_instance_storage')
       = select_tag :shared_instance_storage, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_shared_instance_storage"].to_s), :onchange => "update_value('use_shared_instance_storage', 'shared_instance_storage', 'boolean')"
     %p


### PR DESCRIPTION
This got added back on rebasing a patch, but shouldn't: this is now
handled by roles.
