### PR TITLE
Allow to auto-generate self-signed SSL certificates

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -89,9 +89,10 @@ default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"
 
 default[:nova][:ssl][:enabled] = false
-default[:nova][:ssl][:insecure] = false
 default[:nova][:ssl][:certfile] = "/etc/nova/ssl/certs/signing_cert.pem"
 default[:nova][:ssl][:keyfile] = "/etc/nova/ssl/private/signing_key.pem"
+default[:nova][:ssl][:generate_certs] = false
+default[:nova][:ssl][:insecure] = false
 default[:nova][:ssl][:cert_required] = false
 default[:nova][:ssl][:ca_certs] = "/etc/nova/ssl/certs/ca.pem"
 

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -344,6 +344,54 @@ directory "/var/lock/nova" do
 end
 
 if api == node and api[:nova][:ssl][:enabled]
+  if api[:nova][:ssl][:generate_certs]
+    package "openssl"
+
+    require "fileutils"
+    [:certfile, :keyfile, :ca_certs].each do |k|
+      dir = File.dirname(api[:nova][:ssl][k])
+      if File.exists?(dir)
+        FileUtils.chown_R api[:nova][:user], api[:nova][:group], dir
+      else
+        FileUtils.mkdir_p(dir) {|d| File.chown api[:nova][:user], api[:nova][:group], d}
+      end
+    end
+
+    # Some more ownership fixes:
+    conf_dir = File.dirname api[:nova][:ssl][:ca_certs]
+    FileUtils.chown "root", api[:nova][:group], conf_dir
+    FileUtils.chown "root", api[:nova][:group], File.expand_path("#{conf_dir}/..")  # /etc/nova/ssl
+
+    # Generate private key
+    %x(openssl genrsa -out #{api[:nova][:ssl][:keyfile]} 4096)
+    if $?.exitstatus != 0
+      message = "SSL private key generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+    FileUtils.chown api[:nova][:user], api[:nova][:group], api[:nova][:ssl][:keyfile]
+
+    # Generate certificate signing requests (CSR)
+    ssl_csr_file = "#{conf_dir}/signing_key.csr"
+    ssl_subject = "\"/C=US/ST=Unset/L=Unset/O=Unset/CN=#{api[:fqdn]}\""
+    %x(openssl req -new -key #{api[:nova][:ssl][:keyfile]} -out #{ssl_csr_file} -subj #{ssl_subject})
+    if $?.exitstatus != 0
+      message = "SSL certificate signed requests generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    # Generate self-signed certificate with above CSR
+    %x(openssl x509 -req -days 3650 -in #{ssl_csr_file} -signkey #{api[:nova][:ssl][:keyfile]} -out #{api[:nova][:ssl][:certfile]})
+    if $?.exitstatus != 0
+      message = "SSL self-signed certificate generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    File.delete ssl_csr_file  # Nobody should even try to use this
+  end
+
   unless ::File.exists? api[:nova][:ssl][:certfile]
     message = "Certificate \"#{api[:nova][:ssl][:certfile]}\" is not present."
     Chef::Log.fatal(message)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -119,9 +119,10 @@
       },
       "ssl": {
         "enabled": false,
-        "insecure": false,
         "certfile": "/etc/nova/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/nova/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
         "cert_required": false,
         "ca_certs": "/etc/nova/ssl/certs/ca.pem"
       },

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -81,9 +81,10 @@
             "ssl": {
               "type": "map", "required": true, "mapping": {
                 "enabled": { "type" : "bool", "required" : true },
-                "insecure": { "type" : "bool", "required" : true },
                 "certfile": { "type" : "str", "required" : true },
                 "keyfile": { "type" : "str", "required" : true },
+                "generate_certs": { "type" : "bool", "required" : true },
+                "insecure": { "type" : "bool", "required" : true },
                 "cert_required": { "type" : "bool", "required" : true },
                 "ca_certs": { "type" : "str", "required" : true }
               }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -72,6 +72,7 @@ locale_additions:
           ssl_insecure: SSL Certificate is insecure (for instance, auto-signed)
           ssl_certfile: SSL Certificate File
           ssl_keyfile: SSL (Private) Key File
+          ssl_generate_certs: Generate (self-signed) certificates (implies insecure)
           ssl_cert_required: Require Client Certificate
           ssl_ca_certs: SSL CA Certificates File
           novnc_ssl_header: SSL Support for noVNC

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -64,6 +64,9 @@
             %label{ :for => :ssl_keyfile }= t('.ssl_keyfile')
             = text_field_tag :ssl_keyfile, @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["keyfile"], :size => 80, :onchange => "update_value('ssl/keyfile', 'ssl_keyfile', 'string')"
           %p
+            %label{ :for => :ssl_generate_certs }= t('.ssl_generate_certs')
+            = select_tag :ssl_generate_certs, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["generate_certs"].to_s), :onchange => "update_value('ssl/generate_certs', 'ssl_generate_certs', 'boolean')"
+          %p
             %label{ :for => :ssl_insecure }= t('.ssl_insecure')
             = select_tag :ssl_insecure, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["insecure"].to_s), :onchange => "update_value('ssl/insecure', 'ssl_insecure', 'boolean')"
           %p
@@ -107,6 +110,13 @@
     }
   };
 
+  function toggle_ssl_generate_certs() {
+    if ($('#ssl_generate_certs option:selected').attr('value') == 'true') {
+      $('#ssl_insecure').attr('value', 'true');
+      $('#ssl_cert_required').attr('value', 'false');
+    }
+  };
+
   function toggle_novnc_protocol() {
     if ($('#novnc_protocol option:selected').attr('value') == 'true') {
       $('#novnc_ssl_div').show();
@@ -118,9 +128,11 @@
   $(document).ready(function () {
     toggle_protocol();
     toggle_ssl_cert_required();
+    toggle_ssl_generate_certs();
     toggle_novnc_protocol();
   });
 
   $('#protocol').change(toggle_protocol);
   $('#ssl_cert_required').change(toggle_ssl_cert_required);
   $('#novnc_protocol').change(toggle_novnc_protocol);
+  $('#ssl_generate_certs').change(toggle_ssl_generate_certs);


### PR DESCRIPTION
The setup is rather simple. Instead of a full-blown CA, a CSR is used to create the self-signed certificate.
