### PR TITLE
Stop comparing md5 to know if qemu.conf got changed (suse-only)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -133,12 +133,8 @@ if node.platform == "suse"
       end
 
       if rc.file_edited?
-        # we compare the checksum to know if the file really changed because
-        # the regexp can update a line without changing it...
-        old_md5 = Digest::MD5.hexdigest(File.read('/etc/libvirt/qemu.conf'))
         rc.write_file
-        new_md5 = Digest::MD5.hexdigest(File.read('/etc/libvirt/qemu.conf'))
-        libvirt_restart_needed = (old_md5 != new_md5)
+        libvirt_restart_needed = true
       end
     end
   end


### PR DESCRIPTION
This partially reverts 72fb4e7c.

Chef::Util::FileEdit is now fixed so there's no need to do that hack
anymore.

It's worth mentioning that this code path is specific to SUSE.
