### PR TITLE
Move quantum_metadata_proxy_shared_secret out of network [1/2]

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -76,7 +76,7 @@ default[:nova][:fixed_range] = "10.0.0.0/8"
 default[:nova][:floating_range] = "4.4.4.0/24"
 default[:nova][:num_networks] = 1
 default[:nova][:network_size] = 256
-default[:nova][:network][:quantum_metadata_proxy_shared_secret] = ""
+default[:nova][:quantum_metadata_proxy_shared_secret] = ""
 #
 default[:nova][:network][:flat_network_bridge] = "br100"
 default[:nova][:network][:flat_injected] = true

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -67,7 +67,7 @@ firewall_driver=nova.virt.firewall.NoopFirewallDriver
 service_quantum_metadata_proxy=True
 # Not really secret.  Quantum should be randomly generating this,
 # and we should be using whatever it generates.
-quantum_metadata_proxy_shared_secret=<%= node[:nova][:network][:quantum_metadata_proxy_shared_secret] %>
+quantum_metadata_proxy_shared_secret=<%= node[:nova][:quantum_metadata_proxy_shared_secret] %>
 <% else -%>
 allow_same_net_traffic=<%= node[:nova][:network][:allow_same_net_traffic] ? "True" : "False" %>
 fixed_range=<%= node[:nova][:network][:fixed_range] %>

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -37,6 +37,7 @@
             "use_pip_cache": { "type": "bool", "required": true },
             "use_virtualenv": { "type": "bool", "required": true },
             "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+            "quantum_metadata_proxy_shared_secret": { "type": "str" },
             "network": {
               "type": "map",
               "required": true,
@@ -54,8 +55,7 @@
                 "flat_network_bridge": { "type": "str" },
                 "flat_interface": { "type": "str" },
                 "flat_network_dhcp_start": { "type": "str" },
-                "vlan_start": { "type": "int" },
-                "quantum_metadata_proxy_shared_secret": { "type": "str" }
+                "vlan_start": { "type": "int" }
               }
             },
             "scheduler": {

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -207,7 +207,7 @@ class NovaService < ServiceObject
     end
 
     base["attributes"]["nova"]["db"]["password"] = random_password
-    base["attributes"]["nova"]["network"]["quantum_metadata_proxy_shared_secret"] = random_password
+    base["attributes"]["nova"]["quantum_metadata_proxy_shared_secret"] = random_password
 
     @logger.debug("Nova create_proposal: exiting")
     base


### PR DESCRIPTION
The attributes in network are really about nova-network, which is not
the case here.

Crowbar-Pull-ID: aa4f6c248738dd393b541ee1b9148174fa4ee9f7

Crowbar-Release: pebbles
