### PR TITLE
Bringing support for VMware vCenter 

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -42,6 +42,16 @@ default[:nova][:libvirt_type] = "kvm"
 
 default[:nova][:kvm][:ksm_enabled] = false
 
+#
+# VMWare Settings
+#
+
+default[:nova][:esxi][:host] = "127.0.0.1"
+default[:nova][:esxi][:login] = "root"
+default[:nova][:esxi][:password] = ""
+default[:nova][:esxi][:cluster] = "Cluster"
+default[:nova][:esxi][:datastore] = "datastore1"
+default[:nova][:esxi][:interface] = "vmnic0"
 
 #
 # Scheduler Settings

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -132,6 +132,10 @@ if %w(redhat centos suse).include?(node.platform)
       end
 
       set_boot_kernel_and_trigger_reboot('xen')
+    when "esxi"
+      package "python-suds" do
+        action :install
+      end
     when "qemu"
       package "kvm"
     when "lxc"

--- a/chef/cookbooks/nova/recipes/esxi.rb
+++ b/chef/cookbooks/nova/recipes/esxi.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: nova
+# Recipe:: esxi
+#
+# Copyright 2013, SUSE Linux Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.set[:nova][:libvirt_type] = "esxi"

--- a/chef/cookbooks/nova/recipes/monitor.rb
+++ b/chef/cookbooks/nova/recipes/monitor.rb
@@ -52,6 +52,10 @@ search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
   nova_scale[:computes] << n
 end
 
+search_env_filtered(:node, "roles:nova-multi-compute-esxi") do |n|
+  nova_scale[:computes] << n
+end
+
 if node["roles"].include?("nagios-client")    
   include_recipe "nagios::common"
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1941,7 +1941,11 @@ compute_scheduler_driver=nova.scheduler.filter_scheduler.FilterScheduler
 # include: libvirt.LibvirtDriver, xenapi.XenAPIDriver,
 # fake.FakeDriver, baremetal.BareMetalDriver,
 # vmwareapi.VMWareESXDriver (string value)
+<% if @libvirt_type.eql?('esxi') -%>
+compute_driver=vmwareapi.VMwareVCDriver
+<% else -%>
 compute_driver=libvirt.LibvirtDriver
+<% end -%>
 
 # The default format an ephemeral_volume will be formatted
 # with on creation. (string value)
@@ -2036,6 +2040,7 @@ allow_same_net_traffic=<%= node[:nova][:network][:allow_same_net_traffic] ? "Tru
 # Rescue ari image (string value)
 #rescue_ramdisk_id=<None>
 
+<% if !@libvirt_type.eql?('esxi') -%>
 # Libvirt domain type (valid options are: kvm, lxc, qemu, uml,
 # xen) (string value)
 libvirt_type=<%= @libvirt_type %>
@@ -2059,6 +2064,7 @@ libvirt_inject_key=false
 # Sync virtual and real mouse cursors in Windows VMs (boolean
 # value)
 #use_usb_tablet=true
+<% end -%>
 
 <% if @libvirt_type.eql?('xen') -%>
 <% if @libvirt_migration and @shared_instances -%>
@@ -2294,7 +2300,6 @@ libvirt_ovs_bridge=br-int
 # path can fit your biggest image in glance (string value)
 #powervm_img_local_path=/tmp
 
-
 #
 # Options defined in nova.virt.vmwareapi.driver
 #
@@ -2302,21 +2307,25 @@ libvirt_ovs_bridge=br-int
 # URL for connection to VMware ESX/VC host. Required if
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
-#vmwareapi_host_ip=<None>
+<%= "vmwareapi_host_ip=#{node[:nova][:esxi][:host]}" if @libvirt_type.eql?('esxi') %>
 
 # Username for connection to VMware ESX/VC host. Used only if
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
-#vmwareapi_host_username=<None>
+<%= "vmwareapi_host_username=#{node[:nova][:esxi][:login]}" if @libvirt_type.eql?('esxi') %>
 
 # Password for connection to VMware ESX/VC host. Used only if
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
-#vmwareapi_host_password=<None>
+<%= "vmwareapi_host_password=#{node[:nova][:esxi][:password]}" if @libvirt_type.eql?('esxi') %>
 
 # Name of a VMware Cluster ComputeResource. Used only if
 # compute_driver is vmwareapi.VMwareVCDriver. (string value)
-#vmwareapi_cluster_name=<None>
+<%= "vmwareapi_cluster_name=#{node[:nova][:esxi][:cluster]}" if @libvirt_type.eql?('esxi') %>
+
+# Regex to match the name of a datastore. Used only if
+# compute_driver is vmwareapi.VMwareVCDriver. (string value)
+<%= "datastore_regex=#{node[:nova][:esxi][:datastore]}" if @libvirt_type.eql?('esxi') %>
 
 # The interval used for polling of remote tasks. Used only if
 # compute_driver is vmwareapi.VMwareESXDriver or
@@ -2348,7 +2357,7 @@ libvirt_ovs_bridge=br-int
 
 # Physical ethernet adapter name for vlan networking (string
 # value)
-#vmwareapi_vlan_interface=vmnic0
+vmwareapi_vlan_interface=<%= node[:nova][:esxi][:interface] %>
 
 
 #
@@ -2360,7 +2369,6 @@ libvirt_ovs_bridge=br-int
 # 4.1 default wsdl. Refer readme-vmware to setup (string
 # value)
 #vmwareapi_wsdl_loc=<None>
-
 
 #
 # Options defined in nova.virt.xenapi.agent

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -117,6 +117,14 @@
       "kvm": {
         "ksm_enabled": false
       },
+      "esxi": {
+        "host": "127.0.0.1",
+        "login": "root",
+        "password": "",
+        "cluster": "Cluster",
+        "datastore": "datastore1",
+        "interface": "vmnic0"
+      },
       "ssl": {
         "enabled": false,
         "certfile": "/etc/nova/ssl/certs/signing_cert.pem",
@@ -138,24 +146,28 @@
   "deployment": {
     "nova": {
       "crowbar-revision": 0,
+      "schema-revision": 1,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-hyperv": [ "readying", "ready", "applying" ],
         "nova-multi-compute-kvm": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-qemu": [ "readying", "ready", "applying" ]
+        "nova-multi-compute-qemu": [ "readying", "ready", "applying" ],
+        "nova-multi-compute-esxi": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
         [ "nova-multi-controller" ],
         [ "nova-multi-compute-hyperv" ],
         [ "nova-multi-compute-kvm" ],
-        [ "nova-multi-compute-qemu" ]
+        [ "nova-multi-compute-qemu" ],
+        [ "nova-multi-compute-esxi" ]
       ],
       "element_run_list_order": {
         "nova-multi-controller": 95,
         "nova-multi-compute-hyperv": 97,
         "nova-multi-compute-kvm": 97,
-        "nova-multi-compute-qemu": 97
+        "nova-multi-compute-qemu": 97,
+        "nova-multi-compute-esxi": 97
       },
       "config": {
         "environment": "nova-config-base",

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -78,6 +78,16 @@
                 "ksm_enabled": { "type": "bool", "required": true }
               }
             },
+            "esxi": {
+              "type": "map", "required": true, "mapping": {
+                "host": { "type": "str", "required": true },
+                "login": { "type": "str", "required": true },
+                "password": { "type": "str", "required": true },
+                "cluster": { "type": "str", "required": true },
+                "datastore": { "type": "str", "required": true },
+                "interface": { "type": "str", "required": true }
+              }
+            },
             "ssl": {
               "type": "map", "required": true, "mapping": {
                 "enabled": { "type" : "bool", "required" : true },
@@ -117,6 +127,7 @@
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },
+            "schema-revision": { "type": "int" },
             "element_states": {
               "type": "map",
               "mapping": {

--- a/chef/data_bags/crowbar/migrate/nova/001_add_vmware_patch_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/nova/001_add_vmware_patch_attributes.rb
@@ -1,0 +1,15 @@
+def upgrade ta, td, a, d
+  a['esxi'] = {}
+  a['esxi']['host'] = ta['esxi']['host']
+  a['esxi']['login'] = ta['esxi']['login']
+  a['esxi']['password'] = ta['esxi']['password']
+  a['esxi']['cluster'] = ta['esxi']['cluster']
+  a['esxi']['datastore'] = ta['esxi']['datastore']
+  a['esxi']['interface'] = ta['esxi']['interface']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('esxi')
+  return a, d
+end

--- a/chef/roles/nova-multi-compute-esxi.rb
+++ b/chef/roles/nova-multi-compute-esxi.rb
@@ -1,0 +1,7 @@
+name "nova-multi-compute-esxi"
+description "Installs requirements to run a Compute node in a Nova cluster"
+run_list(
+         "recipe[nova::esxi]",
+         "recipe[nova::compute]",
+         "recipe[nova::monitor]"
+         )

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -69,6 +69,13 @@ locale_additions:
           live_migration: Live Migration
           kvm: KVM Options
           kvm_ksm: Enable Kernel Samepage Merging
+          esxi_header: VMware Support Configuration
+          esxi_host: vCenter Host IP
+          esxi_login: vCenter Username
+          esxi_password: vCenter Password
+          esxi_cluster: Cluster Name
+          esxi_datastore: Datastore Name
+          esxi_interface: VLAN Interface
           ssl_header: SSL Support
           protocol: Protocol
           ssl_insecure: SSL Certificate is insecure (for instance, self-signed)
@@ -138,6 +145,7 @@ debs:
     - mysql-client
     - socat
     - python-mox
+    - python-suds
 rpms:
   centos-6.4:
     repos:

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -67,7 +67,7 @@ class NovaService < ServiceObject
       "nova-multi-controller" => [ head.name ],
       "nova-multi-compute-hyperv" => hyperv.map { |x| x.name },
       "nova-multi-compute-kvm" => kvm.map { |x| x.name },
-      "nova-multi-compute-qemu" => qemu.map { |x| x.name }  
+      "nova-multi-compute-qemu" => qemu.map { |x| x.name }
     }
 
     base["attributes"][@bc_name]["git_instance"] = ""
@@ -295,6 +295,9 @@ class NovaService < ServiceObject
     elements["nova-multi-compute-qemu"].each do |n|
         nodes[n] += 1
     end unless elements["nova-multi-compute-qemu"].nil?
+    elements["nova-multi-compute-esxi"].each do |n|
+        nodes[n] += 1
+    end unless elements["nova-multi-compute-esxi"].nil?
 
     nodes.each do |key,value|
         if value > 1

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -46,6 +46,27 @@
         %label{ :for => :kvm_ksm }= t('.kvm_ksm')
         = select_tag :kvm_ksm, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["kvm"]["ksm_enabled"].to_s), :onchange => "update_value('kvm/ksm_enabled', 'kvm_ksm', 'boolean')"
 
+    %label.section-header{ :for => :esxi_div }= t('.esxi_header')
+    %div.section{ :id => :esxi_div }
+      %p
+        %label{ :for => :esxi_host }= t('.esxi_host')
+        %input#esxi_host{:type => "text", :name => "esxi_host", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["host"], :onchange => "update_value('esxi/host', 'esxi_host', 'string')"}
+      %p
+        %label{ :for => :esxi_login }= t('.esxi_login')
+        %input#esxi_login{:type => "text", :name => "esxi_login", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["login"], :onchange => "update_value('esxi/login', 'esxi_login', 'string')"}
+      %p
+        %label{ :for => :esxi_password }= t('.esxi_password')
+        %input#esxi_password{:type => "password", :name => "esxi_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["password"], :onchange => "update_value('esxi/password', 'esxi_password', 'string')"}
+      %p
+        %label{ :for => :esxi_cluster }= t('.esxi_cluster')
+        %input#esxi_cluster{:type => "text", :name => "esxi_cluster", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["cluster"], :onchange => "update_value('esxi/cluster', 'esxi_cluster', 'string')"}
+      %p
+        %label{ :for => :esxi_datastore }= t('.esxi_datastore')
+        %input#esxi_datastore{:type => "text", :name => "esxi_datastore", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["datastore"], :onchange => "update_value('esxi/datastore', 'esxi_datastore', 'string')"}
+      %p
+        %label{ :for => :esxi_interface }= t('.esxi_interface')
+        %input#esxi_datastore{:type => "text", :name => "esxi_interface", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["esxi"]["interface"], :onchange => "update_value('esxi/interface', 'esxi_interface', 'string')"}
+
     %label.section-header{ :for => :protocol_div }= t('.ssl_header')
     %div.section{ :id => :protocol_div }
       %p

--- a/crowbar_framework/app/views/barclamp/nova/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_deployment.html.haml
@@ -8,6 +8,7 @@
       "nova-multi-controller": { "unique": false, "count": 1 },
       "nova-multi-compute-hyperv": { "unique": false, "count": -1 },
       "nova-multi-compute-kvm": { "unique": false, "count": -1 },
+      "nova-multi-compute-esxi": { "unique": false, "count": 1 },
       "nova-multi-compute-qemu": { "unique": false, "count": -1 }
     };
     node_selector($('#drag_drop'), constraints);


### PR DESCRIPTION
OpenStack Compute supports the VMware vSphere. This patch brings support for vmwareapi.VMwareVCDriver. 

With this driver that lets nova-compute communicate with a VMware vCenter server managing a cluster of ESX hosts. With this driver and access to shared storage, advanced vSphere features like vMotion, High Availability, and Dynamic Resource Scheduling (DRS) are available. With this driver, one nova-compute service is run per vCenter cluster.
