### PR TITLE
Set the correct device names for "fixed" and "public"

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -190,14 +190,12 @@ node.set[:nova][:network][:floating_range] = "#{nova_floating["subnet"]}/#{mask_
 fip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "nova_fixed")
 if fip
   fixed_interface = fip.interface
-  fixed_interface = "#{fip.interface}.#{fip.vlan}" if fip.use_vlan
 else
   fixed_interface = nil
 end
 pip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public")
 if pip
   public_interface = pip.interface
-  public_interface = "#{pip.interface}.#{pip.vlan}" if pip.use_vlan
 else
   public_interface = nil
 end


### PR DESCRIPTION
Since https://github.com/crowbar/barclamp-deployer/pull/147 was merged the
deployer barclamp automatically include the vlan id in the interface attribute.
This should fix linux-bridge support again, which was broke since the above
mentioned pull request.
