### PR TITLE
Resolve issue with objectstore.s3server

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -42,6 +42,7 @@ else
 end
 
 nova_package("api")
+nova_package("objectstore")
 
 keystone_host = keystone[:fqdn]
 keystone_protocol = keystone["keystone"]["api"]["protocol"]


### PR DESCRIPTION
Because our installation requires the use of euca2ools for registering new images, we need to run the nova-objectstore service. It would be nice to have installed nova-objectstore package.
