### PR TITLE
Fix nova.conf for quantum linuxbridge driver

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -245,14 +245,16 @@ compute_manager=nova.compute.manager.ComputeManager
 #cert_manager=nova.cert.manager.CertManager
 
 # full class name for the Manager for network (string value)
-<% if node[:nova][:network][:dhcp_enabled] -%>
-<% if node[:nova][:network][:tenant_vlans] -%>
+<% if node[:nova][:networking_backend] != "quantum" -%>
+<%   if node[:nova][:network][:dhcp_enabled] -%>
+<%     if node[:nova][:network][:tenant_vlans] -%>
 network_manager=nova.network.manager.VlanManager
-<% else -%>
+<%     else -%>
 network_manager=nova.network.manager.FlatDHCPManager
-<% end -%>
-<% else -%>
+<%     end -%>
+<%   else -%>
 network_manager=nova.network.manager.FlatManager
+<%   end -%>
 <% end -%>
 
 # full class name for the Manager for scheduler (string value)
@@ -1082,11 +1084,7 @@ dhcpbridge=<%= @dhcpbridge %>
 
 # Driver used to create ethernet devices. (string value)
 <% if node[:nova][:networking_backend] == "quantum" -%>
-<% if @quantum_networking_plugin == "openvswitch" -%>
-linuxnet_interface_driver=nova.network.linux_net.LinuxOVSInterfaceDriver
-<% elsif @quantum_networking_plugin == "linuxbridge" -%>
-linuxnet_interface_driver=nova.network.linux_net.LinuxBridgeInterfaceDriver
-<% end -%>
+linuxnet_interface_driver=""
 <% end -%>
 
 
@@ -1128,6 +1126,7 @@ linuxnet_interface_driver=nova.network.linux_net.LinuxBridgeInterfaceDriver
 # Options defined in nova.network.manager
 #
 
+<% if node[:nova][:networking_backend] != "quantum" -%>
 # Bridge for simple network instances (string value)
 <%= "flat_network_bridge=#{node[:nova][:network][:flat_network_bridge]}" if !node[:nova][:network][:tenant_vlans] %>
 
@@ -1218,7 +1217,7 @@ fixed_range=<%= node[:nova][:network][:fixed_range] %>
 
 # Indicates underlying L3 management library (string value)
 #l3_lib=nova.network.l3.LinuxNetL3
-
+<% end -%>
 
 #
 # Options defined in nova.network.quantumv2.api
@@ -2095,11 +2094,11 @@ block_migration_flag=VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIG
 
 # The libvirt VIF driver to configure the VIFs. (string value)
 <% if node[:nova][:networking_backend] == "quantum" -%>
-<% if @quantum_networking_plugin == "openvswitch" -%>
+<%   if @quantum_networking_plugin == "openvswitch" -%>
 libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtHybridOVSBridgeDriver
-<% elsif @quantum_networking_plugin == "linuxbridge" -%>
-libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtBridgeDriver
-<% end -%>
+<%   elsif @quantum_networking_plugin == "linuxbridge" -%>
+libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtGenericVIFDriver
+<%   end -%>
 <% end -%>
 
 # Libvirt handlers for remote volumes. (list value)


### PR DESCRIPTION
That the correct network_manager value when using quatum with linuxbridge.
Addtionally stop createing config values that are just needed for nova-network.
Support for nova-network was dropped some time ago for this barclamp.
