### PR TITLE
Fixed quantum floating IP smoketest failure [1/2]

### DIFF
--- a/smoketest/00-deploy-nova-vm.test
+++ b/smoketest/00-deploy-nova-vm.test
@@ -15,18 +15,21 @@
 ip_re='(([0-9]{1,3}\.){3}[0-9]{1,3})'
 declare -a instances images
 cleanup() {
-    trap '' QUIT TERM
-    local instance_name
-    for instance_name in "${instances[@]}"; do
-        nova console-log $instance_name > "$LOGDIR/nova-$instance_name.console.log"
-        nova delete $instance_name
-        ssh-keygen -f "/root/.ssh/known_hosts" -R "${floating_ips[$instance_name]}" &>/dev/null
-        nova floating-ip-delete "${floating_ips[$instance_name]}"
-        while nova list |grep -q $instance_name; do sleep 1; done
-    done
-    nova keypair-delete smoketest
-    ssh-agent -k
-    quantum security-group-delete smoketest
+    # Only cleanup if the tests were successful
+    if [ $? -eq 0 ]; then
+        trap '' QUIT TERM
+        local instance_name
+        for instance_name in "${instances[@]}"; do
+            nova console-log $instance_name > "$LOGDIR/nova-$instance_name.console.log"
+            nova delete $instance_name
+            ssh-keygen -f "/root/.ssh/known_hosts" -R "${floating_ips[$instance_name]}" &>/dev/null
+            nova floating-ip-delete "${floating_ips[$instance_name]}"
+            while nova list |grep -q $instance_name; do sleep 1; done
+        done
+        nova keypair-delete smoketest
+        ssh-agent -k
+        quantum security-group-delete smoketest
+    fi
 }
 
 
@@ -241,6 +244,7 @@ fi
 
 
 
+usable=false
 if [ $in_use = true ]; then
     echo -e "\n\nVolume tests stage - volume attach: $volume_id  instance_id: $used_instance_id attach status:	SUCCESS\n\n"
     echo -e "Volume tests stage - accessibility test:    Target instance_id: $used_instance_id attached_volume_id: $volume_id  device: $v_device instance_ip: ${floating_ips[$used_instance_name]} used sshkey: $sshkey"


### PR DESCRIPTION
This pull fixes a failure during the nova smoketest where it fails to ping floating IPs.

Also fixed:

Don't blow away the setup if the nova smoketest fails so something is left to debug.
Fixed a failure in the nova smoketest where the smoketest script would bomb if the ssh to probe the disks failed.

 smoketest/00-deploy-nova-vm.test |   28 ++++++++++++++++------------
 1 file changed, 16 insertions(+), 12 deletions(-)

Crowbar-Pull-ID: 07aada52af97d9bfca558de286e64b9cbb55da2d

Crowbar-Release: pebbles
