### PR TITLE
Force "use_vlan" to false on nova_fixed when using vlan modes

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -236,6 +236,17 @@ class NovaService < ServiceObject
           net_svc.allocate_ip "default", "os_sdn", "host", n
         else
           net_svc.enable_interface "default", "nova_fixed", n
+          if quantum["attributes"]["quantum"]["networking_mode"] == "vlan"
+            # Force "use_vlan" to false in VLAN mode (linuxbridge and ovs). We
+            # need to make sure that the network recipe does NOT create the
+            # VLAN interfaces (ethX.VLAN)
+            node = NodeObject.find_node_by_name n
+            if node.crowbar["crowbar"]["network"]["nova_fixed"]["use_vlan"]
+              @logger.info("Forcing use_vlan to false for the nova_fixed network on node #{n}")
+              node.crowbar["crowbar"]["network"]["nova_fixed"]["use_vlan"] = false
+              node.save
+            end
+          end
         end
       end unless all_nodes.nil?
     else


### PR DESCRIPTION
When ovs is used in vlan-mode quantums sets up an ovs-bridge to do the vlan
tagging. That bridge needs be attached to a none VLAN interface in order to
work correctly.

When linux-bridge is used quantum's linux bridge agent will create the correct
vlan interfaces automatically.
