### PR TITLE
Remove attempts to reinstall python-keystoneclient from Keystone cookbook into Nova venv

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -32,13 +32,6 @@ end
 
 unless node[:nova][:use_gitrepo]
   package "python-novaclient"
-else
-  pfs_and_install_deps "keystone" do
-    cookbook "keystone"
-    cnode keystone
-    path File.join(nova_path,"keystone")
-    virtualenv venv_path
-  end
 end
 
 nova_package("api")

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -88,7 +88,7 @@
         "pip://python-novaclient",
         "pip://python-ceilometerclient",
         "pip://python-cinderclient",
-        "pip://python-keystoneclient>=0.2.0",
+        "pip://python-keystoneclient>=0.3.0",
         "pip://prettytable>=0.6,<0.8",
         "pip://websockify<0.4",
         "pip://stevedore>=0.7",


### PR DESCRIPTION
the current Nova requires next version of keystoneclient

Traceback (most recent call last):
  File "/opt/nova/.venv/bin/nova-api", line 4, in <module>
    from pkg_resources import require; require('nova==2013.1.4.a20.g43f2a4c')
  File "/opt/nova/.venv/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/pkg_resources.py", line 2711, in <module>
    parse_requirements(**requires**), Environment()
  File "/opt/nova/.venv/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/pkg_resources.py", line 588, in resolve
    raise VersionConflict(dist,req) # XXX put more info here
pkg_resources.VersionConflict: (python-keystoneclient 0.2.5 (/opt/nova/.venv/lib/python2.7/site-packages), Requirement.parse('python-keystoneclient>=0.3.0'))
