### PR TITLE
Create and redistribute ssh keys for Nova user

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -89,6 +89,7 @@ default[:nova][:network][:vlan_start] = 100
 
 default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"
+default[:nova][:service_ssh_key] = ""
 
 default[:nova][:ssl][:enabled] = false
 default[:nova][:ssl][:certfile] = "/etc/nova/ssl/certs/signing_cert.pem"


### PR DESCRIPTION
The nova non-life migration feature requires to be able
to ssh from nova@ to other nova@ users on other compute nodes.
Setup the ssh keys properly for that.
