### PR TITLE
Merging bug fix from mesa to roxy [1/1]

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -150,9 +150,9 @@ if vncproxy_public_host.nil? or vncproxy_public_host.empty?
 end
 Chef::Log.info("VNCProxy server at #{vncproxy_public_host}")
 
-directory "/etc/nova/" do
+directory "/etc/nova" do
    mode 0755
-   action :nothing
+   action :create
 end
 
 cookbook_file "/etc/default/nova-common" do


### PR DESCRIPTION
This pull request merges bug fix:

DE#1191 - nova-manage command failed because of directory permission preventing the reading of nova.conf -- resolves nagios warning issues

 chef/cookbooks/nova/recipes/config.rb |    5 +++++
 1 file changed, 5 insertions(+)

Crowbar-Pull-ID: dba21dd466c13e36b30e209718e24953a44f13f8

Crowbar-Release: roxy
