### PR TITLE
Fix dependency error message after quantum rename

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -203,7 +203,7 @@ class NovaService < ServiceObject
     end
 
     if base["attributes"]["nova"]["quantum_instance"] == ""
-      raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "quantum"))
+      raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "neutron"))
     end
 
     base["attributes"]["nova"]["db"]["password"] = random_password


### PR DESCRIPTION
Fix dependency error message after the quantum got renamed to neutron
