### PR TITLE
Create and redistribute ssh keys for Nova user [1/1]

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -89,6 +89,7 @@ default[:nova][:network][:vlan_start] = 100
 
 default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"
+default[:nova][:service_ssh_key] = ""
 
 default[:nova][:ssl][:enabled] = false
 default[:nova][:ssl][:certfile] = "/etc/nova/ssl/certs/signing_cert.pem"

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -234,6 +234,44 @@ if !nova_controller.nil? and nova_controller.length > 0 and nova_controller[0].n
 
 end
 
+# Create and distribute ssh keys for nova user on all compute nodes
+unless node[:nova][:user].empty? or node["etc"]["passwd"][node[:nova][:user]].nil?
+  nova_home_dir = node["etc"]["passwd"][node[:nova][:user]]["dir"]
+end
+
+unless nova_home_dir.nil? or nova_home_dir.empty?
+
+  ruby_block "nova_read_ssh_public_key" do
+    block do
+      node.set[:nova][:service_ssh_key] = File.read("#{nova_home_dir}/.ssh/id_rsa.pub")
+      node.save
+    end
+    action :nothing
+  end
+
+  execute "Create Nova SSH key" do
+    command "su #{node[:nova][:user]} -c \"ssh-keygen -q -t rsa  -P '' -f '#{nova_home_dir}/.ssh/id_rsa'\""
+    creates "#{nova_home_dir}/.ssh/id_rsa.pub"
+    notifies :create, "ruby_block[nova_read_ssh_public_key]"
+  end
+
+  ssh_auth_keys = ""
+  search_env_filtered(:node, "roles:nova-multi-compute-kvm") do |n|
+      ssh_auth_keys += n[:nova][:service_ssh_key]
+  end
+  search_env_filtered(:node, "roles:nova-multi-compute-xen") do |n|
+      ssh_auth_keys += n[:nova][:service_ssh_key]
+  end
+  search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
+      ssh_auth_keys += n[:nova][:service_ssh_key]
+  end
+
+  file "#{nova_home_dir}/.ssh/authorized_keys" do
+    content ssh_auth_keys
+    owner node[:nova][:user]
+  end
+end
+
 link "/etc/libvirt/qemu/networks/autostart/default.xml" do
   action :delete
 end

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -220,9 +220,16 @@ end
 
 if node[:nova][:use_gitrepo]
   package("libvirt-bin")
+
   create_user_and_dirs "nova" do
     opt_dirs [node[:nova][:instances_path]]
     user_gid "libvirtd"
+  end
+
+  # This account needs to be ssh'able, so must have a login shell
+  user "nova" do
+    shell "/bin/bash"
+    action :modify  
   end
 
   execute "cp_policy.json" do


### PR DESCRIPTION
Create and redistribute ssh keys for Nova user

```
The nova non-life migration feature requires to be able
to ssh from nova@ to other nova@ users on other compute nodes.
Setup the ssh keys properly for that.
```

 chef/cookbooks/nova/attributes/default.rb |    1 +
 chef/cookbooks/nova/recipes/compute.rb    |   38 +++++++++++++++++++++++++++++
 chef/cookbooks/nova/recipes/config.rb     |    7 ++++++
 3 files changed, 46 insertions(+)

Crowbar-Pull-ID: 87ff74083456503cbe390e7cf6ef13dba3f0b883

Crowbar-Release: roxy
