### PR TITLE
removed unversioned activesupport entry in crowbar.yml [2/2]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -18,7 +18,7 @@
 barclamp:
   name: nova
   display: Nova
-  description: 'OpenStack Compute: Provision and manage large network of virtual machines'
+  description: 'OpenStack Compute: Provision and manage large network of virtual machines '
   version: 0
   requires:
     - '@crowbar'


### PR DESCRIPTION
barclamps/crowbar/crobar.yml included both a versioned and unversioned entry for 
activesupport.  This was causing activesupport 4.0.0 to also be included, which
requires a later version (1.9.3) of Ruby than is in this release.  This was causing
the bluepill gem to fail during installation of crowbar on the admin node when
being tested on the CI systems. The unversioned entry has been removed.

 crowbar.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 9ce39b4358e9dda943e9069c9d4396eae2a5266f

Crowbar-Release: mesa-1.6.1
