### PR TITLE
Run nova-manage db_sync as the nova-user

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -71,6 +71,8 @@ database_user "grant privileges to the nova database user" do
 end
 
 execute "nova-manage db sync" do
+  user node[:nova][:user]
+  group node[:nova][:group]
   command "nova-manage db sync"
   action :run
 end


### PR DESCRIPTION
Avoids issues with the ownership of /var/log/nova/nova-manage.log logfile. As
the nova init script runs the db_sync task as well.
