### PR TITLE
Fixed failure in nova smoketests [1/1]

### DIFF
--- a/smoketest/00-deploy-nova-vm.test
+++ b/smoketest/00-deploy-nova-vm.test
@@ -556,7 +556,7 @@ if (($(bc <<< "$cinder_version>$cinder_broken_ver"))); then
         vl_id=$make_b && sleep 3
         b_device_id=$(nova volume-list | grep "$vl_id" | awk {'print $2'})
 
-        for ((i=1; i<=5; i++)); do
+        for ((i=1; i<=10; i++)); do
             b_device_status=$(nova volume-list | grep $b_device_id | awk {'print $4'})
             echo -e "Quering volume  volume_name: volume-from-image  volume_id: $b_device_id status attempt #$i"
             echo -e "Block device actual status: $b_device_status"


### PR DESCRIPTION
This change increases the number of retries for a specific test.  This test was failing in my setup
because it was taking longer than the retry window for the status to switch from Downloading to Available.

 smoketest/00-deploy-nova-vm.test |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 0a2fad7dc6318c0af6838ed0cffbc26568404d70

Crowbar-Release: roxy
