### PR TITLE
VMware vCenter support for roxy branch

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -43,6 +43,15 @@ default[:nova][:libvirt_type] = "kvm"
 
 default[:nova][:kvm][:ksm_enabled] = false
 
+#
+# VMWare Settings
+#
+
+default[:nova][:vcenter][:host] = ""
+default[:nova][:vcenter][:user] = ""
+default[:nova][:vcenter][:password] = ""
+default[:nova][:vcenter][:clusters] = []
+default[:nova][:vcenter][:interface] = ""
 
 #
 # Scheduler Settings

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -134,6 +134,8 @@ if %w(redhat centos suse).include?(node.platform)
       end
 
       set_boot_kernel_and_trigger_reboot('xen')
+    when "vmware"
+      package "python-suds"
     when "qemu"
       package "kvm"
     when "lxc"

--- a/chef/cookbooks/nova/recipes/monitor.rb
+++ b/chef/cookbooks/nova/recipes/monitor.rb
@@ -52,6 +52,10 @@ search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
   nova_scale[:computes] << n
 end
 
+search_env_filtered(:node, "roles:nova-multi-compute-vmware") do |n|
+  nova_scale[:computes] << n
+end
+
 search_env_filtered(:node, "roles:nova-multi-compute-xen") do |n|
   nova_scale[:computes] << n
 end

--- a/chef/cookbooks/nova/recipes/vmware.rb
+++ b/chef/cookbooks/nova/recipes/vmware.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: nova
+# Recipe:: vmware
+#
+# Copyright 2013, SUSE Linux Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.set[:nova][:libvirt_type] = "vmware"

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1935,7 +1935,11 @@ ram_allocation_ratio=<%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 # fake.FakeDriver, baremetal.BareMetalDriver,
 # vmwareapi.VMwareESXDriver, vmwareapi.VMwareVCDriver (string
 # value)
+<% if @libvirt_type.eql?('vmware') -%>
+compute_driver=vmwareapi.VMwareVCDriver
+<% else -%>
 compute_driver=libvirt.LibvirtDriver
+<% end -%>
 
 # The default format an ephemeral_volume will be formatted
 # with on creation. (string value)
@@ -1987,6 +1991,7 @@ allow_same_net_traffic=<%= node[:nova][:network][:allow_same_net_traffic] ? "Tru
 # Rescue ari image (string value)
 #rescue_ramdisk_id=<None>
 
+<% if !@libvirt_type.eql?('vmware') -%>
 # Libvirt domain type (valid options are: kvm, lxc, qemu, uml,
 # xen) (string value)
 libvirt_type=<%= @libvirt_type %>
@@ -2010,6 +2015,7 @@ libvirt_inject_key=false
 # Sync virtual and real mouse cursors in Windows VMs (boolean
 # value)
 #use_usb_tablet=true
+<% end -%>
 
 <% if @libvirt_type.eql?('xen') -%>
 <% if @libvirt_migration and @shared_instances -%>
@@ -3299,20 +3305,28 @@ connection=<%= @database_connection %>
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
 #host_ip=<None>
+<%= "host_ip=#{node[:nova][:vcenter][:host]}" if @libvirt_type.eql?('vmware') %>
 
 # Username for connection to VMware ESX/VC host. Used only if
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
 #host_username=<None>
+<%= "host_username=#{node[:nova][:vcenter][:user]}" if @libvirt_type.eql?('vmware') %>
 
 # Password for connection to VMware ESX/VC host. Used only if
 # compute_driver is vmwareapi.VMwareESXDriver or
 # vmwareapi.VMwareVCDriver. (string value)
 #host_password=<None>
+<%= "host_password=#{node[:nova][:vcenter][:password]}" if @libvirt_type.eql?('vmware') %>
 
 # Name of a VMware Cluster ComputeResource. Used only if
 # compute_driver is vmwareapi.VMwareVCDriver. (multi valued)
 #cluster_name=<None>
+<% if @libvirt_type.eql?('vmware') -%>
+ <% node[:nova][:vcenter][:clusters].each do |cluster| -%>
+cluster_name=<%= cluster %>
+ <% end -%>
+<% end -%>
 
 # Regex to match the name of a datastore. Used only if
 # compute_driver is vmwareapi.VMwareVCDriver. (string value)
@@ -3352,7 +3366,7 @@ connection=<%= @database_connection %>
 # Physical ethernet adapter name for vlan networking (string
 # value)
 #vlan_interface=vmnic0
-
+<%= "vlan_interface=#{node[:nova][:vcenter][:interface]}" if @libvirt_type.eql?('vmware') %>
 
 #
 # Options defined in nova.virt.vmwareapi.vim

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -66,8 +66,8 @@
         "network_size": 256
       },
       "scheduler": {
-	"ram_allocation_ratio": 1.0,
-	"cpu_allocation_ratio": 16.0
+        "ram_allocation_ratio": 1.0,
+        "cpu_allocation_ratio": 16.0
       },
       "db": {
         "password": "",
@@ -80,6 +80,13 @@
       },
       "kvm": {
         "ksm_enabled": false
+      },
+      "vcenter": {
+        "host": "",
+        "user": "",
+        "password": "",
+        "clusters": [],
+        "interface": "vmnic0"
       },
       "ssl": {
         "enabled": false,
@@ -102,12 +109,13 @@
   "deployment": {
     "nova": {
       "crowbar-revision": 0,
-      "schema-revision": 3,
+      "schema-revision": 4,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-hyperv": [ "readying", "ready", "applying" ],
         "nova-multi-compute-kvm": [ "readying", "ready", "applying" ],
         "nova-multi-compute-qemu": [ "readying", "ready", "applying" ],
+        "nova-multi-compute-vmware": [ "readying", "ready", "applying" ],
         "nova-multi-compute-xen": [ "readying", "ready", "applying" ]
       },
       "elements": {},
@@ -116,6 +124,7 @@
         [ "nova-multi-compute-hyperv" ],
         [ "nova-multi-compute-kvm" ],
         [ "nova-multi-compute-qemu" ],
+        [ "nova-multi-compute-vmware" ],
         [ "nova-multi-compute-xen" ]
       ],
       "element_run_list_order": {
@@ -123,6 +132,7 @@
         "nova-multi-compute-hyperv": 97,
         "nova-multi-compute-kvm": 97,
         "nova-multi-compute-qemu": 97,
+        "nova-multi-compute-vmware": 97,
         "nova-multi-compute-xen": 97
       },
       "config": {

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -85,6 +85,15 @@
                 "ksm_enabled": { "type": "bool", "required": true }
               }
             },
+            "vcenter": {
+              "type": "map", "required": true, "mapping": {
+                "host": { "type": "str", "required": true },
+                "user": { "type": "str", "required": true },
+                "password": { "type": "str", "required": true },
+                "clusters": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+                "interface": { "type": "str", "required": true }
+              }
+            },
             "ssl": {
               "type": "map", "required": true, "mapping": {
                 "enabled": { "type" : "bool", "required" : true },

--- a/chef/data_bags/crowbar/migrate/nova/004_add_vmware_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/nova/004_add_vmware_attributes.rb
@@ -1,0 +1,14 @@
+def upgrade ta, td, a, d
+  a['vcenter'] = {}
+  a['vcenter']['host'] = ta['vcenter']['host']
+  a['vcenter']['user'] = ta['vcenter']['user']
+  a['vcenter']['password'] = ta['vcenter']['password']
+  a['vcenter']['clusters'] = ta['vcenter']['clusters']
+  a['vcenter']['interface'] = ta['vcenter']['interface']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('vcenter')
+  return a, d
+end

--- a/chef/roles/nova-multi-compute-vmware.rb
+++ b/chef/roles/nova-multi-compute-vmware.rb
@@ -1,0 +1,7 @@
+name "nova-multi-compute-vmware"
+description "Installs requirements to run a Compute node in a Nova cluster"
+run_list(
+         "recipe[nova::vmware]",
+         "recipe[nova::compute]",
+         "recipe[nova::monitor]"
+         )

--- a/crowbar_framework/app/helpers/nova_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/nova_barclamp_helper.rb
@@ -31,6 +31,10 @@ module NovaBarclampHelper
       "nova-multi-compute-qemu" => {
         "unique" => false,
         "count" => -1
+      },
+      "nova-multi-compute-vmware" => {
+        "unique" => false,
+        "count" => 1
       }
     }
   end

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -185,6 +185,9 @@ class NovaService < ServiceObject
     elements["nova-multi-compute-qemu"].each do |n|
         nodes[n] += 1
     end unless elements["nova-multi-compute-qemu"].nil?
+    elements["nova-multi-compute-vmware"].each do |n|
+        nodes[n] += 1
+    end unless elements["nova-multi-compute-vmware"].nil?
     elements["nova-multi-compute-xen"].each do |n|
         nodes[n] += 1
         node = NodeObject.find_node_by_name(n)

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -38,6 +38,18 @@
 
     %fieldset
       %legend
+        = t(".vmware_header")
+
+      = string_field %w(vcenter host)
+      = string_field %w(vcenter user)
+      = password_field %w(vcenter password)
+      = array_string_field %w(vcenter clusters)
+      %span.help-block
+        = t('.vmware_cluster_hint')
+      = string_field %w(vcenter interface)
+
+    %fieldset
+      %legend
         = t(".ssl_header")
 
       = boolean_field %w(ssl enabled), :collection => :ssl_protocols_for_nova, "data-sslprefix" => "ssl", "data-sslcert" => "/etc/nova/ssl/certs/signing_cert.pem", "data-sslkey" => "/etc/nova/ssl/private/signing_key.pem"

--- a/crowbar_framework/config/locales/nova.en.yml
+++ b/crowbar_framework/config/locales/nova.en.yml
@@ -21,6 +21,14 @@ en:
         kvm_header: KVM Options
         kvm:
           ksm_enabled: Enable Kernel Samepage Merging
+        vmware_header: VMWare vCenter configuration
+        vcenter:
+          host: vCenter IP Address
+          user: vCenter Username
+          password: vCenter Password
+          clusters: Cluster Names
+          interface: VLAN Interface
+        vmware_cluster_hint: A comma-separated list of cluster names
         ssl_header: SSL Support
         ssl:
           enabled: Protocol


### PR DESCRIPTION
OpenStack Compute supports the VMware vSphere. This patch brings support for vmwareapi.VMwareVCDriver.

With this driver that lets nova-compute communicate with a VMware vCenter server managing a cluster of ESX hosts. With this driver and access to shared storage, advanced vSphere features like vMotion, High Availability, and Dynamic Resource Scheduling (DRS) are available. With this driver, one nova-compute service is run per vCenter cluster.
