### PR TITLE
 Bug fix: apply use specified hypervisor settings

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -105,7 +105,7 @@ glance_api_servers=<%= @glance_server_ip %>:<%= @glance_server_port %>
 sql_connection=<%= @database_connection %>
 <% end -%>
 connection_type=libvirt
-libvirt_type=qemu
+libvirt_type=<%= node[:nova][:libvirt_type] %>
 libvirt_cpu_mode=none
 libvirt_use_virtio_for_bridges=True
 compute_driver=libvirt.LibvirtDriver


### PR DESCRIPTION
Apply user specified settings for hypervisor instead of hardwiring qemu.
Notice that if deployment is in virtual environment then current logic will switch to qemu
irrespective what is specified by user.

Also nova smoketest only tests qemu and will change default nova setting to qemu but that will be reflected in UI.

 .../cookbooks/nova/templates/default/nova.conf.erb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 9422d7dc16c93260d0ad7338bf9423d752126378

Crowbar-Release: mesa-1.6.1
