### PR TITLE
Set verbose by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -3,7 +3,6 @@
   "description": "installs and configures the Openstack Nova component. It relies upon the network and glance barclamps for normal operation.",
   "attributes": {
     "nova": {
-      "debug": false,
       "database_instance": "none",
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
@@ -15,7 +14,8 @@
       "trusted_flavors": false,
       "libvirt_type": "kvm",
       "use_novnc": true,
-      "verbose": false,
+      "debug": false,
+      "verbose": true,
       "use_shared_instance_storage": false,
       "use_migration": false,
       "use_syslog": false,


### PR DESCRIPTION
Nova log files are really useless without INFO logging, and
it doesn't add that much overhead (compared to debug logging).
