### PR TITLE
Always explicitly set rpc_backend in nova.conf

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1546,10 +1546,8 @@ notification_driver=nova.openstack.common.notifier.rpc_notifier
 
 # The messaging module to use, defaults to kombu. (string
 # value)
-<% if (node.platform == "centos") or (node.platform == "redhat") %>
-#we have to set it explicitely since for rhel it qpid by default and not affect other distribution cause we not support anything except of rabbit
+# Note: explicitely set this because of RHEL (where qpid is used by default)
 rpc_backend=nova.openstack.common.rpc.impl_kombu
-<% end %>
 
 # Size of RPC thread pool (integer value)
 #rpc_thread_pool_size=64


### PR DESCRIPTION
It doesn't hurt, and it's better than losing the commented out version.
