### PR TITLE
Cleanup fixup.

### DIFF
--- a/smoketest/00-deploy-nova-vm.test
+++ b/smoketest/00-deploy-nova-vm.test
@@ -34,11 +34,12 @@ cleanup() {
         trap '' QUIT TERM
         local instance_name
         for instance_name in "${instances[@]}"; do
-            nova console-log $instance_name > "$LOGDIR/nova-$instance_name.console.log"
-            nova delete $instance_name
-            ssh-keygen -f "/root/.ssh/known_hosts" -R "$(get_instance_floating_ip $instance_name)" &>/dev/null
-            nova floating-ip-delete "$(get_instance_floating_ip $instance_name)"
-            while nova list |grep -q $instance_name; do sleep 1; done
+            instance_id=$(nova list | grep "$instance_name" | awk {'print $2'})
+            [[ $instance_id ]] && nova console-log $instance_name > "$LOGDIR/nova-$instance_name.console.log"
+            [[ $instance_id ]] && nova delete $instance_name
+            ssh-keygen -f "/root/.ssh/known_hosts" -R "${floating_ips[$instance_name]}" &>/dev/null
+            nova floating-ip-delete "${floating_ips[$instance_name]}"
+            [[ $instance_id ]] && while nova list | grep -q $instance_id; do sleep 1; done
         done
         nova keypair-delete smoketest
         ssh-agent -k
@@ -638,7 +639,7 @@ if (($(bc <<< "$cinder_version>$cinder_broken_ver"))); then
 
     if [[ $ssh_ok = true  ]]; then
         echo -e "\n\n\nTests complete\n\n\n Cleaning up: instance_name: $b_device-test and volume: $b_device_id"
-        nova delete $b_device-test 
+        nova delete $in_id
         sleep 10
         for ((i=1; i<=5; i++)); do
           removed_instance_id=$(nova list | grep "$b_device-test")
@@ -646,7 +647,9 @@ if (($(bc <<< "$cinder_version>$cinder_broken_ver"))); then
           [[ ! $removed_instance_id ]] && cleanup_ok_instance=true && break || sleep 5 && continue
         done
 
-        nova volume-delete $b_device_id
+        blk_dev_id=$(nova volume-list | grep "$b_device_id" | awk {'print $2'})
+        [[ $blk_dev_id ]] && nova volume-delete $blk_dev_id
+
         sleep 10
         for ((i=1; i<=5; i++)); do
             removed_volume_id=$(nova volume-list | grep "$b_device_id")


### PR DESCRIPTION
```
- VM instance cleanup steps are skipped, if VM instance was deleted before cleanup.
- Line 639: Nova delete argument changed from "Instance name" to "Instance id".
- Line 647: Nova volume-delete argument changed from "Volume name" to "Volume id", deletion is performed only if this volume still exists in moment of performing "volume-delete".
```
