### PR TITLE
Restore virtual guests by default on host reboot

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -676,7 +676,7 @@ instance_usage_audit=True
 
 # Whether to start guests that were running before the host
 # rebooted (boolean value)
-#resume_guests_state_on_host_boot=false
+resume_guests_state_on_host_boot=true
 
 # Number of times to retry network allocation on failures
 # (integer value)


### PR DESCRIPTION
Helps at least with some "availability" accross reboots..
