### PR TITLE
Drop unused cookbook_file for nova-common

### DIFF
--- a/chef/cookbooks/nova/files/default/nova-common
+++ b/chef/cookbooks/nova/files/default/nova-common
@@ -1,5 +1,0 @@
-# defaults file for all the nova services
-#
-# Setting this to 1 will allow the services to run, it is set to 0 by default
-# to prevent the services from running until they have been configured.
-ENABLED=1

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -158,14 +158,6 @@ directory "/etc/nova" do
    action :create
 end
 
-cookbook_file "/etc/default/nova-common" do
-  source "nova-common"
-  owner node[:nova][:user]
-  group "root"
-  mode 0640
-  action :nothing
-end
-
 def mask_to_bits(mask)
   octets = mask.split(".")
   count = 0


### PR DESCRIPTION
It was never run, so it's not really needed.
