### PR TITLE
Run chef-client for all compute nodes in the same batch

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -112,11 +112,13 @@
       "elements": {},
       "element_order": [
         [ "nova-multi-controller" ],
-        [ "nova-multi-compute-hyperv" ],
-        [ "nova-multi-compute-kvm" ],
-        [ "nova-multi-compute-qemu" ],
-        [ "nova-multi-compute-vmware" ],
-        [ "nova-multi-compute-xen" ]
+        [
+          "nova-multi-compute-hyperv",
+          "nova-multi-compute-kvm",
+          "nova-multi-compute-qemu",
+          "nova-multi-compute-vmware",
+          "nova-multi-compute-xen"
+        ]
       ],
       "element_run_list_order": {
         "nova-multi-controller": 95,


### PR DESCRIPTION
The element_order attribute specifies how batches are going to be run
when applying the roles. Until now, we put each compute role in its own
batch; but that's not required as a node can only have one compute role,
and we have no issue running chef-client on all the compute nodes in
parallel.

Very concretely, this means that the xen role will now be applied at the
same time as the kvm role, while before, we were waiting for the kvm
role to be applied before applying the xen one.

The issue with the previous approach is that the periodic chef-client on
the xen node can be triggered while the other roles are being applied,
and it will possibly reboot the node -- making the node non-reachable
from apply_role when it's its turn to have a chef-client role.

While this change won't 100% fix the above issue, it will greatly reduce
the risk. And it's a change that makes sense anyway.

This helps a bit with https://bugzilla.novell.com/show_bug.cgi?id=859865
