### PR TITLE
Move lock_path to /var/run

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -298,13 +298,6 @@ else
   oat_server = node
 end
 
-
-directory "/var/lock/nova" do
-  action :create
-  owner node[:nova][:user]
-  group "root"
-end
-
 # only require certs for nova controller
 if api == node and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-multi-controller")
   if api[:nova][:ssl][:generate_certs]

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1361,7 +1361,7 @@ security_group_api=neutron
 
 # Directory to use for lock files. Default to a temp directory
 # (string value)
-lock_path=/var/lock/nova
+lock_path=/var/run/nova
 
 
 #


### PR DESCRIPTION
/var/lock is blacklisted on openSUSE
