### PR TITLE
Generate a node-specific UUID

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -76,12 +76,19 @@ end
 if %w(redhat centos suse).include?(node.platform)
   package "libvirt"
 
+  # Generate a UUID, as DMI's system uuid is unreliable
+  if node[:nova][:host_uuid].nil?
+    node.normal[:nova][:host_uuid] = `uuidgen`.strip
+    node.save
+  end
+
   template "/etc/libvirt/libvirtd.conf" do
     source "libvirtd.conf.erb"
     group "root"
     owner "root"
     mode 0644
     variables(
+      :libvirtd_host_uuid => node[:nova][:host_uuid],
       :libvirtd_listen_tcp => node[:nova]["use_migration"] ? 1 : 0,
       :libvirtd_listen_addr => Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address,
       :libvirtd_auth_tcp => node[:nova]["use_migration"] ? "none" : "sasl"

--- a/chef/cookbooks/nova/templates/default/libvirtd.conf.erb
+++ b/chef/cookbooks/nova/templates/default/libvirtd.conf.erb
@@ -367,7 +367,7 @@ auth_tcp = "<%= @libvirtd_auth_tcp %>"
 # NB This default all-zeros UUID will not work. Replace
 # it with the output of the 'uuidgen' command and then
 # uncomment this entry
-#host_uuid = "00000000-0000-0000-0000-000000000000"
+host_uuid = "<%= @libvirtd_host_uuid %>"
 
 ###################################################################
 # Keepalive protocol:


### PR DESCRIPTION
Certain batches of Dell and IBM hardware seems to
have the same hardware product UUID. As libvirtd
requires a globally unique identifier for live
migration, lets create one on our own.
