### PR TITLE
 Make sure that the right ssh public key is saved in the node info

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -256,6 +256,7 @@ ruby_block "nova_read_ssh_public_key" do
       node.save
     end
   end
+  only_if { ::File.exist?("#{node[:nova][:home_dir]}/.ssh/id_rsa.pub") }
 end
 
 ssh_auth_keys = ""


### PR DESCRIPTION
The old way of saving the node public key relied on a notification, and
so only happened the very first time, when the ssh key was created. If,
for any reason, this went wrong, then there was no way to get it fixed.

Instead, on each chef-client run, we check if the node info contains the
right data, and if not, we save it.
