### PR TITLE
Restart Nova services if ceph.conf changes

### DIFF
--- a/chef/cookbooks/nova/definitions/nova_package.rb
+++ b/chef/cookbooks/nova/definitions/nova_package.rb
@@ -62,6 +62,7 @@ define :nova_package, :enable => true do
     end
 
     subscribes :restart, resources(:template => "/etc/nova/nova.conf")
+    subscribes :restart, resources("template[/etc/ceph/ceph.conf]")
   end
 
 end


### PR DESCRIPTION
It is likely that a new monitor got added then, and
the service needs to reread the config file.

(cherry picked from commit 70ed22068ec1aa5c136cfa8826b4d0cfd39487f5)
