### PR TITLE
Use strings and not symbols as keys for hashes in migration scripts

### DIFF
--- a/chef/data_bags/crowbar/migrate/nova/002_neutron_rename.rb
+++ b/chef/data_bags/crowbar/migrate/nova/002_neutron_rename.rb
@@ -1,12 +1,12 @@
 
 def upgrade ta, td, a, d
-  a[:networking_backend] = "neutron" if a[:networking_backend] == "quantum"
-  if a[:quantum_metadata_proxy_shared_secret]
-    a[:neutron_metadata_proxy_shared_secret] = a[:quantum_metadata_proxy_shared_secret]
+  a['networking_backend'] = "neutron" if a['networking_backend'] == "quantum"
+  if a['quantum_metadata_proxy_shared_secret']
+    a['neutron_metadata_proxy_shared_secret'] = a['quantum_metadata_proxy_shared_secret']
     a.delete 'quantum_metadata_proxy_shared_secret'
   end
-  if a[:quantum_instance]
-    a[:neutron_instance] = a[:quantum_instance]
+  if a['quantum_instance']
+    a['neutron_instance'] = a['quantum_instance']
     a.delete 'quantum_instance'
   end
   ### Delete Quantum Keystone endpoint here
@@ -14,13 +14,13 @@ def upgrade ta, td, a, d
 end
 
 def downgrade ta, td, a, d
-  a[:networking_backend] = "quantum" if a[:networking_backend] == "neutron"
-  if a[:neutron_metadata_proxy_shared_secret]
-    a[:quantum_metadata_proxy_shared_secret] = a[:neutron_metadata_proxy_shared_secret]
+  a['networking_backend'] = "quantum" if a['networking_backend'] == "neutron"
+  if a['neutron_metadata_proxy_shared_secret']
+    a['quantum_metadata_proxy_shared_secret'] = a['neutron_metadata_proxy_shared_secret']
     a.delete 'neutron_metadata_proxy_shared_secret'
   end
-  if a[:neutron_instance]
-    a[:quantum_instance] = a[:neutron_instance]
+  if a['neutron_instance']
+    a['quantum_instance'] = a['neutron_instance']
     a.delete 'neutron_instance'
   end
   ### Delete Neutron Keystone endpoint here

--- a/chef/data_bags/crowbar/migrate/nova/004_add_vmware_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/nova/004_add_vmware_attributes.rb
@@ -1,16 +1,16 @@
 def upgrade ta, td, a, d
-  a[:vcenter] = {}
-  a[:vcenter][:host] = ta[:vcenter][:host]
-  a[:vcenter][:user] = ta[:vcenter][:user]
-  a[:vcenter][:password] = ta[:vcenter][:password]
-  a[:vcenter][:clusters] = ta[:vcenter][:clusters]
-  a[:vcenter][:interface] = ta[:vcenter][:interface]
-  unless a[:esxi].nil?
-    a[:vcenter][:host] = a[:esxi][:host]
-    a[:vcenter][:user] = a[:esxi][:login]
-    a[:vcenter][:password] = a[:esxi][:password]
-    a[:vcenter][:clusters] = [ a[:esxi][:cluster] ]
-    a[:vcenter][:interface] = a[:esxi][:interface] unless a[:esxi][:interface].nil?
+  a['vcenter'] = {}
+  a['vcenter']['host'] = ta['vcenter']['host']
+  a['vcenter']['user'] = ta['vcenter']['user']
+  a['vcenter']['password'] = ta['vcenter']['password']
+  a['vcenter']['clusters'] = ta['vcenter']['clusters']
+  a['vcenter']['interface'] = ta['vcenter']['interface']
+  unless a['esxi'].nil?
+    a['vcenter']['host'] = a['esxi']['host']
+    a['vcenter']['user'] = a['esxi']['login']
+    a['vcenter']['password'] = a['esxi']['password']
+    a['vcenter']['clusters'] = [ a['esxi']['cluster'] ]
+    a['vcenter']['interface'] = a['esxi']['interface'] unless a['esxi']['interface'].nil?
     a.delete('esxi')
   end
   d['element_states'] = td['element_states']
@@ -24,20 +24,20 @@ def upgrade ta, td, a, d
 end
 
 def downgrade ta, td, a, d
-   a[:esxi] = {}
-   a[:esxi][:host] = ta[:esxi][:host]
-   a[:esxi][:login] = ta[:esxi][:login]
-   a[:esxi][:password] = ta[:esxi][:password]
-   a[:esxi][:cluster] = ta[:esxi][:cluster]
-   a[:esxi][:datastore] = ta[:esxi][:datastore]
-   a[:esxi][:interface] = ta[:esxi][:interface]
-  unless a[:vcenter].nil?
-    a[:esxi][:host] = a[:vcenter][:host]
-    a[:esxi][:login] = a[:vcenter][:user]
-    a[:esxi][:password] = a[:vcenter][:password]
-    a[:esxi][:cluster] = a[:vcenter][:clusters][0] || ""
-    a[:esxi][:datastore] = ta[:esxi][:datastore]
-    a[:esxi][:interface] = a[:vcenter][:interface]
+   a['esxi'] = {}
+   a['esxi']['host'] = ta['esxi']['host']
+   a['esxi']['login'] = ta['esxi']['login']
+   a['esxi']['password'] = ta['esxi']['password']
+   a['esxi']['cluster'] = ta['esxi']['cluster']
+   a['esxi']['datastore'] = ta['esxi']['datastore']
+   a['esxi']['interface'] = ta['esxi']['interface']
+  unless a['vcenter'].nil?
+    a['esxi']['host'] = a['vcenter']['host']
+    a['esxi']['login'] = a['vcenter']['user']
+    a['esxi']['password'] = a['vcenter']['password']
+    a['esxi']['cluster'] = a['vcenter']['clusters'][0] || ""
+    a['esxi']['datastore'] = ta['esxi']['datastore']
+    a['esxi']['interface'] = a['vcenter']['interface']
     a.delete('vcenter')
   end
   d['element_states'] = td['element_states']

--- a/chef/data_bags/crowbar/migrate/nova/005_remove_nova-network.rb
+++ b/chef/data_bags/crowbar/migrate/nova/005_remove_nova-network.rb
@@ -5,7 +5,7 @@ def upgrade ta, td, a, d
 end
 
 def downgrade ta, td, a, d
-  a[:networking_backend] = ta[:networking_backend]
-  a[:network] = ta[:network]
+  a['networking_backend'] = ta['networking_backend']
+  a['network'] = ta['network']
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/nova/006_add_vmware_datastore.rb
+++ b/chef/data_bags/crowbar/migrate/nova/006_add_vmware_datastore.rb
@@ -1,9 +1,9 @@
 def upgrade ta, td, a, d
-  a[:vcenter][:datastore] = ta[:vcenter][:datastore]
+  a['vcenter']['datastore'] = ta['vcenter']['datastore']
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a[:vcenter].delete('datastore')
+  a['vcenter'].delete('datastore')
   return a, d
 end


### PR DESCRIPTION
I had a failure for one migration (while migration a role, not a
proposal) because of this.
