### PR TITLE
Install and start Multipath daemon

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -34,6 +34,11 @@ default[:nova][:use_shared_instance_storage] = false
 # Hypervisor Settings
 #
 default[:nova][:libvirt_type] = "kvm"
+unless %w(suse).include?(node.platform)
+  default[:nova][:libvirt_use_multipath] = false
+else
+  default[:nova][:libvirt_use_multipath] = true
+end
 
 #
 # KVM Settings

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -319,6 +319,18 @@ execute "set vhost_net module" do
   command "grep -q 'vhost_net' /etc/modules || echo 'vhost_net' >> /etc/modules"
 end
 
+if node[:nova][:libvirt_use_multipath]
+  package "multipath-tools"
+
+  service "multipathd" do
+    action [:enable, :start]
+  end
+
+  service "boot.multipath" do
+    action [:enable]
+  end
+end
+
 unless %w(redhat centos suse).include?(node.platform)
   #since using native ovs we have to gain acess to lower networking functions
   service "libvirt-bin" do

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -377,6 +377,7 @@ template "/etc/nova/nova.conf" do
             :ec2_host => admin_api_host,
             :ec2_dmz_host => public_api_host,
             :libvirt_migration => node[:nova]["use_migration"],
+            :libvirt_enable_multipath => node[:nova][:libvirt_enable_multipath],
             :shared_instances => node[:nova]["use_shared_instance_storage"],
             :dns_server_public_ip => dns_server_public_ip,
             :glance_server_protocol => glance_server_protocol,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2214,10 +2214,10 @@ libvirt_ovs_bridge=br-int
 #glusterfs_mount_point_base=$state_path/mnt
 
 # use multipath connection of the iSCSI volume (boolean value)
-#libvirt_iscsi_use_multipath=false
+<%= "libvirt_iscsi_use_multipath=true" if @libvirt_enable_multipath %>
 
 # use multipath connection of the iSER volume (boolean value)
-#libvirt_iser_use_multipath=false
+<%= "libvirt_iser_use_multipath=true" if @libvirt_enable_multipath %>
 
 # Path or URL to Scality SOFS configuration file (string
 # value)


### PR DESCRIPTION
Needed for Multipath'ed FC support in libvirt/Nova, so enable
it at least for SUSE platform.
