### PR TITLE
Enable the ComputeV3 endpoints

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -105,6 +105,17 @@ keystone_register "register ec2 service" do
   action :add_service
 end
 
+keystone_register "register computev3 service" do
+  protocol keystone_settings['protocol']
+  host keystone_settings['internal_url_host']
+  port keystone_settings['admin_port']
+  token keystone_settings['admin_token']
+  service_name "computev3"
+  service_type "computev3"
+  service_description "Openstack Nova Service V3"
+  action :add_service
+end
+
 keystone_register "register nova endpoint" do
   protocol keystone_settings['protocol']
   host keystone_settings['internal_url_host']
@@ -132,6 +143,19 @@ keystone_register "register nova ec2 endpoint" do
   endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_ec2_port}/services/Cloud"
 #  endpoint_global true
 #  endpoint_enabled true
+  action :add_endpoint_template
+end
+
+keystone_register "register computev3 endpoint" do
+  protocol keystone_settings['protocol']
+  host keystone_settings['internal_url_host']
+  port keystone_settings['admin_port']
+  token keystone_settings['admin_token']
+  endpoint_service "computev3"
+  endpoint_region "RegionOne"
+  endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v3"
+  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
+  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
   action :add_endpoint_template
 end
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2672,7 +2672,7 @@ cinder_api_insecure=<%= @cinder_insecure ? 'True' : 'False' %>
 #
 
 # Whether the V3 API is enabled or not (boolean value)
-#enabled=false
+enabled=true
 
 # A list of v3 API extensions to never load. Specify the
 # extension aliases here. (list value)


### PR DESCRIPTION
Nova v2 is deprecated, and Tempest expects V3 to be available.
(it is still optionally though, but I think it makes to unconditionally
enable it by default in SUSE Cloud)
