### PR TITLE
Make Nova V3 API optional and disabled by default

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -27,6 +27,8 @@ default[:nova][:db][:password] = nil
 default[:nova][:db][:user] = "nova"
 default[:nova][:db][:database] = "nova"
 
+# Feature settings
+default[:nova][:enable_v3_api] = false
 default[:nova][:use_migration] = false
 default[:nova][:use_shared_instance_storage] = false
 

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -105,15 +105,17 @@ keystone_register "register ec2 service" do
   action :add_service
 end
 
-keystone_register "register computev3 service" do
-  protocol keystone_settings['protocol']
-  host keystone_settings['internal_url_host']
-  port keystone_settings['admin_port']
-  token keystone_settings['admin_token']
-  service_name "computev3"
-  service_type "computev3"
-  service_description "Openstack Nova Service V3"
-  action :add_service
+if api[:nova][:enable_v3_api]
+  keystone_register "register computev3 service" do
+    protocol keystone_settings['protocol']
+    host keystone_settings['internal_url_host']
+    port keystone_settings['admin_port']
+    token keystone_settings['admin_token']
+    service_name "computev3"
+    service_type "computev3"
+    service_description "Openstack Nova Service V3"
+    action :add_service
+  end
 end
 
 keystone_register "register nova endpoint" do
@@ -146,17 +148,19 @@ keystone_register "register nova ec2 endpoint" do
   action :add_endpoint_template
 end
 
-keystone_register "register computev3 endpoint" do
-  protocol keystone_settings['protocol']
-  host keystone_settings['internal_url_host']
-  port keystone_settings['admin_port']
-  token keystone_settings['admin_token']
-  endpoint_service "computev3"
-  endpoint_region "RegionOne"
-  endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v3"
-  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
-  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
-  action :add_endpoint_template
+if api[:nova][:enable_v3_api]
+  keystone_register "register computev3 endpoint" do
+    protocol keystone_settings['protocol']
+    host keystone_settings['internal_url_host']
+    port keystone_settings['admin_port']
+    token keystone_settings['admin_token']
+    endpoint_service "computev3"
+    endpoint_region "RegionOne"
+    endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v3"
+    endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
+    endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
+    action :add_endpoint_template
+  end
 end
 
 crowbar_pacemaker_sync_mark "create-nova_register"

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -409,6 +409,7 @@ template "/etc/nova/nova.conf" do
             :ssl_key_file => api[:nova][:ssl][:keyfile],
             :ssl_cert_required => api[:nova][:ssl][:cert_required],
             :ssl_ca_file => api[:nova][:ssl][:ca_certs],
+            :enable_nova_v3_api => api[:nova][:enable_v3_api],
             :oat_appraiser_host => oat_server[:hostname],
             :oat_appraiser_port => "8443",
             :has_itxt => has_itxt

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2672,7 +2672,7 @@ cinder_api_insecure=<%= @cinder_insecure ? 'True' : 'False' %>
 #
 
 # Whether the V3 API is enabled or not (boolean value)
-enabled=true
+enabled=<%= @enable_nova_v3_api ? 'True' : 'False' %>
 
 # A list of v3 API extensions to never load. Specify the
 # extension aliases here. (list value)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -26,6 +26,7 @@
       "use_gitbarclamp": true,
       "use_pip_cache": true,
       "use_virtualenv": true,
+      "enable_v3_api": false,
       "neutron_url_timeout": 30,
       "pfs_deps": [
           "python-libvirt",
@@ -103,7 +104,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 7,
+      "schema-revision": 10,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-hyperv": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -36,6 +36,7 @@
             "use_gitbarclamp": { "type": "bool", "required": true },
             "use_pip_cache": { "type": "bool", "required": true },
             "use_virtualenv": { "type": "bool", "required": true },
+            "enable_v3_api": { "type": "bool", "required": true },
             "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "neutron_metadata_proxy_shared_secret": { "type": "str" },
             "neutron_url_timeout": {"type": "int"},

--- a/chef/data_bags/crowbar/migrate/nova/010_add_nova_v3.rb
+++ b/chef/data_bags/crowbar/migrate/nova/010_add_nova_v3.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['enable_v3_api'] = ta['enable_v3_api']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete 'enable_v3_api'
+  return a, d
+end


### PR DESCRIPTION
It seems upstream decided to put v3 off by default for
icehouse. So adjust our cookbook accordingly.
