### PR TITLE
Synchronize nova.conf template with Icehouse

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -194,7 +194,7 @@ rpc_backend=rabbit
 # The default exchange under which topics are scoped. May be
 # overridden by an exchange name specified in the
 # transport_url option. (string value)
-#control_exchange=openstack
+control_exchange=nova
 
 
 #


### PR DESCRIPTION
It's a huge patch, but with no functional change. The only real
additional change is that control_exchange is now set to nova (instead
of openstack), as expected by ceilometer.
