### PR TITLE
Use crowbar built-in reboot handler for xen kernel

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -52,10 +52,15 @@ def set_boot_kernel_and_trigger_reboot(flavor='default')
     %x[sed -i -e "s;^default.*;default #{default_boot};" /boot/grub/menu.lst]
   end
 
-  # trigger reboot through reboot_handler, if kernel-$flavor is not yet
-  # running
-  unless %x[uname -r].include?(flavor)
-    node.run_state[:reboot] = true
+  # trigger reboot managed by run_remote_chef_client() function if
+  # kernel-$flavor is not yet running
+  if %x[uname -r].include?(flavor)
+    node[:reboot] = ""
+    node.save
+  else
+    node[:reboot] = "require"
+    node.save
+    log "current kernel not the required flavor. reboot needed"
   end
 end
 


### PR DESCRIPTION
When applying the Xen role, the compute node needs to reboot into the
Xen kernel flavor. Crowbars service object has a built-in reboot handler
which waits until the reboot is completed. This has the nice side effect
that the proposal commit is finished when the reboot is done. That's
currently not the case.

https://bugzilla.novell.com/show_bug.cgi?id=878012
