### PR TITLE
enable open-iscsi service

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -90,6 +90,12 @@ if %w(redhat centos suse).include?(node.platform)
   service "open-iscsi" do
     supports :status => true, :start => true, :stop => true, :restart => true
     action [:enable, :start]
+    if node.platform == "suse"
+      # Workaround broken open-iscsi init scripts that return a failed code
+      # but start the service anyway. run a status command afterwards to
+      # see what the real status is (bnc#885834)
+      start_command "/etc/init.d/open-iscsi start; /etc/init.d/open-iscsi status"
+    end
   end
 
   case node[:nova][:libvirt_type]


### PR DESCRIPTION
This also fixes rebooting with attached cinder volumes
which would otherwise fail, because network is shutdown before the volumes are detached
https://bugzilla.novell.com/show_bug.cgi?id=889127
