### PR TITLE
set force_config_drive to 'always'

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -81,6 +81,8 @@ default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"
 default[:nova][:service_ssh_key] = ""
 
+default[:nova][:force_config_drive] = "always"
+
 default[:nova][:rbd][:user] = ""
 default[:nova][:rbd][:secret_uuid] = ""
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1898,7 +1898,7 @@ ram_allocation_ratio=<%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 
 # Set to force injection to take place on a config drive (if
 # set, valid options are: always) (string value)
-#force_config_drive=<None>
+force_config_drive=<%= node[:nova][:force_config_drive] %>
 
 # Name and optionally path of the tool used for ISO image
 # creation (string value)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -27,6 +27,7 @@
       "use_pip_cache": true,
       "use_virtualenv": true,
       "enable_v3_api": false,
+      "force_config_drive": "always",
       "neutron_url_timeout": 30,
       "pfs_deps": [
           "python-libvirt",
@@ -104,7 +105,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 10,
+      "schema-revision": 11,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-hyperv": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -37,6 +37,7 @@
             "use_pip_cache": { "type": "bool", "required": true },
             "use_virtualenv": { "type": "bool", "required": true },
             "enable_v3_api": { "type": "bool", "required": true },
+            "force_config_drive": { "type": "str", "required": true },
             "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "neutron_metadata_proxy_shared_secret": { "type": "str" },
             "neutron_url_timeout": {"type": "int"},


### PR DESCRIPTION
This is required for nova file injection to work and we need that for
trove.
