### PR TITLE
Set keystone_ec2_url in nova.conf

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -565,7 +565,7 @@ auth_strategy=keystone
 #lockout_window=15
 
 # URL to get token from ec2 request. (string value)
-#keystone_ec2_url=http://localhost:5000/v2.0/ec2tokens
+keystone_ec2_url=<%= @keystone_settings['internal_auth_url'] %>ec2tokens
 
 # Return the IP address as private dns hostname in describe
 # instances (boolean value)


### PR DESCRIPTION
This is required when keystone is not on the same host as the nova
controller, or when using HA.
