### PR TITLE
Fix VMware spelling

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -49,7 +49,7 @@ end
 default[:nova][:kvm][:ksm_enabled] = false
 
 #
-# VMWare Settings
+# VMware Settings
 #
 
 default[:nova][:vcenter][:host] = ""

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -38,7 +38,7 @@ en:
         kvm_header: 'KVM Options'
         kvm:
           ksm_enabled: 'Enable Kernel Samepage Merging'
-        vmware_header: 'VMWare vCenter Settings'
+        vmware_header: 'VMware vCenter Settings'
         vcenter:
           host: 'vCenter Host/IP Address'
           user: 'vCenter Username'


### PR DESCRIPTION
We would like to fix VMware spelling from bad one VMWare.
