### PR TITLE
Generate certs on all nodes for HA

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -250,7 +250,7 @@ else
 end
 
 # only require certs for nova controller
-if api == node and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-multi-controller")
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-multi-controller")
   if api[:nova][:ssl][:generate_certs]
     package "openssl"
     ruby_block "generate_certs for nova" do
@@ -329,7 +329,7 @@ else
   api_novnc_ssl_keyfile = ''
 end
 
-if api == node and api[:nova][:novnc][:ssl][:enabled]
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) and api[:nova][:novnc][:ssl][:enabled]
   # No check if we're using certificate info from nova-api
   unless ::File.exists? api_novnc_ssl_certfile or api[:nova][:novnc][:ssl][:certfile].empty?
     message = "Certificate \"#{api_novnc_ssl_certfile}\" is not present."


### PR DESCRIPTION
With HA, HTTPS and automatic generation of self-signed certificates, all
controller nodes except for one are missing the cert files, and the api
and novncproxy services fail to start on those nodes.

This is a workaround to generate the certs on all controller nodes when HA is
enabled.

Another possible solution (to trigger the condition for generating the certs) would be to make sure the ['api' variable](https://github.com/bkutil/barclamp-nova/blob/7cc8e23b67695ea3ce05088bebec30095e6178db/chef/cookbooks/nova/recipes/config.rb#L77) is assigned based on finding the current node, i.e:

```
if apis.length > 0
   api = apis.find { |a| a.name == node.name } || apis.first
```

For this change, though, I'm not sure if picking the `api[0]` has some deeper meaning (as it is also used for the keystone, dns_servers, etc. below) and so, if changing this would not break other things.
