### PR TITLE
Generate certs on all nodes for HA

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -250,7 +250,7 @@ else
 end
 
 # only require certs for nova controller
-if api == node and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-multi-controller")
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-multi-controller")
   if api[:nova][:ssl][:generate_certs]
     package "openssl"
     ruby_block "generate_certs for nova" do
@@ -329,7 +329,7 @@ else
   api_novnc_ssl_keyfile = ''
 end
 
-if api == node and api[:nova][:novnc][:ssl][:enabled]
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) and api[:nova][:novnc][:ssl][:enabled]
   # No check if we're using certificate info from nova-api
   unless ::File.exists? api_novnc_ssl_certfile or api[:nova][:novnc][:ssl][:certfile].empty?
     message = "Certificate \"#{api_novnc_ssl_certfile}\" is not present."


### PR DESCRIPTION
With HA, HTTPS and automatic generation of self-signed certificates, all
controller nodes except for one are missing the cert files, and the api
and novncproxy services fail to start.

This is a workaround to generate the certs on all nodes when HA is
enabled.
(cherry picked from commit 7cc8e23b67695ea3ce05088bebec30095e6178db)
