### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
+++ b/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
@@ -63,6 +63,14 @@ parser.add_argument('--os-auth-url',
 parser.add_argument('--os_auth_url',
                     help=argparse.SUPPRESS)
 
+parser.add_argument('--os-region-name',
+                    metavar='<region-name>',
+                    default=os.environ.get('OS_REGION_NAME', None),
+                    help='Name of the region.')
+
+parser.add_argument('--os_region_name',
+                    help=argparse.SUPPRESS)
+
 parser.add_argument('--endpoint-type',
                     metavar='<endpoint-type>',
                     default='internalURL',
@@ -104,6 +112,7 @@ c = nova_client.Client(args.os_username,
                        args.os_password,
                        args.os_tenant_name,
                        auth_url=args.os_auth_url,
+                       region_name=args.os_region_name,
                        endpoint_type=args.endpoint_type,
                        insecure=args.insecure,
                        http_log_debug=args.debug)

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -124,7 +124,7 @@ keystone_register "register nova endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "nova"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v2/$(tenant_id)s"
   endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2/$(tenant_id)s"
   endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2/$(tenant_id)s"
@@ -139,7 +139,7 @@ keystone_register "register nova ec2 endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "ec2"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_ec2_port}/services/Cloud"
   endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_ec2_port}/services/Admin"
   endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_ec2_port}/services/Cloud"
@@ -155,7 +155,7 @@ if api[:nova][:enable_v3_api]
     port keystone_settings['admin_port']
     token keystone_settings['admin_token']
     endpoint_service "computev3"
-    endpoint_region "RegionOne"
+    endpoint_region keystone_settings['endpoint_region']
     endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v3"
     endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"
     endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v3"

--- a/chef/cookbooks/nova/recipes/availability_zones.rb
+++ b/chef/cookbooks/nova/recipes/availability_zones.rb
@@ -36,6 +36,9 @@ command << "--os-tenant-name"
 command << keystone_settings['default_tenant']
 command << "--os-auth-url"
 command << keystone_settings['internal_auth_url']
+command << "--os-region-name"
+command << keystone_settings['endpoint_region']
+
 if keystone_settings['insecure'] || nova_insecure
   command << "--insecure"
 end

--- a/chef/cookbooks/nova/recipes/trusted_flavors.rb
+++ b/chef/cookbooks/nova/recipes/trusted_flavors.rb
@@ -33,7 +33,7 @@ if node[:nova][:trusted_flavors]
   nova_insecure = node[:nova][:ssl][:insecure]
   ssl_insecure = keystone_settings['insecure'] || nova_insecure
 
-  novacmd = "nova --os-username #{keystone_settings['service_user']} --os-password #{keystone_settings['service_password']} --os-tenant-name #{keystone_settings['service_tenant']} --os-auth-url #{keystone_settings['internal_auth_url']} --endpoint-type internalURL"
+  novacmd = "nova --os-username #{keystone_settings['service_user']} --os-password #{keystone_settings['service_password']} --os-tenant-name #{keystone_settings['service_tenant']} --os-auth-url #{keystone_settings['internal_auth_url']} --endpoint-type internalURL --os-region-name '#{keystone_settings['endpoint_region']}'"
   if ssl_insecure
     novacmd = "#{novacmd} --insecure"
   end

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1492,7 +1492,7 @@ neutron_admin_tenant_name=<%= @keystone_settings['service_tenant'] %>
 
 # Region name for connecting to neutron in admin context
 # (string value)
-#neutron_region_name=<None>
+neutron_region_name=<%= @keystone_settings['endpoint_region'] %>
 
 # Authorization URL for connecting to neutron in admin context
 # (string value)
@@ -2100,7 +2100,7 @@ cinder_catalog_info=volume:cinder:internalURL
 #cinder_endpoint_template=<None>
 
 # Region name of this node (string value)
-#os_region_name=<None>
+os_region_name=<%= @keystone_settings['endpoint_region'] %>
 
 # Location of ca certificates file to use for cinder client
 # requests. (string value)


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
