### PR TITLE
Moving OpenStack networks definitions to barclamp-neutron

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -164,15 +164,15 @@ class NovaService < PacemakerServiceObject
       if neutron["attributes"]["neutron"]["networking_mode"] == "gre"
         net_svc.allocate_ip "default", "os_sdn", "host", n
       else
-        net_svc.enable_interface "default", "nova_fixed", n
+        net_svc.enable_interface "default", "fixed", n
         if neutron["attributes"]["neutron"]["networking_mode"] == "vlan"
           # Force "use_vlan" to false in VLAN mode (linuxbridge and ovs). We
           # need to make sure that the network recipe does NOT create the
           # VLAN interfaces (ethX.VLAN)
           node = NodeObject.find_node_by_name n
-          if node.crowbar["crowbar"]["network"]["nova_fixed"]["use_vlan"]
+          if node.crowbar["crowbar"]["network"]["fixed"]["use_vlan"]
             @logger.info("Forcing use_vlan to false for the nova_fixed network on node #{n}")
-            node.crowbar["crowbar"]["network"]["nova_fixed"]["use_vlan"] = false
+            node.crowbar["crowbar"]["network"]["fixed"]["use_vlan"] = false
             node.save
           end
         end


### PR DESCRIPTION
This is pull request for moving OpenStack Nova networks to barclamp-neutron.
This change will:
- simplify network configuration
- gives better flexibility for user deployments.

Warning!!! Please don't merge this until it will be tested

Depends on:
    crowbar/crowbar#2071
