### PR TITLE
Fix live migration when HA is enabled in nova (bnc#900966)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2052,7 +2052,7 @@ xvpvncproxy_base_url=http://<%= @vncproxy_public_host %>:<%= node[:nova][:ports]
 
 # IP address on which instance vncservers should listen
 # (string value)
-vncserver_listen=<%= @bind_host %>
+vncserver_listen="0.0.0.0"
 
 # The address to which proxy clients (like nova-xvpvncproxy)
 # should connect (string value)


### PR DESCRIPTION
This was failing because qemu was listening to the admin IP address of
the compute node instead of 0.0.0.0, and this IP address is not
available on the destination compute host.

https://bugzilla.suse.com/show_bug.cgi?id=900966

(cherry picked from commit 8458bbaa8b3271bfb7f7bbdbbd0982f09402f1c6)
