### PR TITLE
Switch to Cinder Volume V2 service

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2396,7 +2396,7 @@ xvpvncproxy_host=<%= @bind_host %>
 # <service_type>:<service_name>:<endpoint_type> (string value)
 # Deprecated group/name - [DEFAULT]/cinder_catalog_info
 #catalog_info=volume:cinder:publicURL
-catalog_info=volume:cinder:internalURL
+catalog_info=volumev2:cinder:internalURL
 
 # Override service catalog lookup with template for cinder
 # endpoint e.g. http://localhost:8776/v1/%(project_id)s


### PR DESCRIPTION
The V1 API is deprecated and since the Horizon dashboard defaults
to V2 as well, it makes more sense to use the same API level
from all services.