### PR TITLE
Allow deploying of more than one vmware compute node (bnc#901252)

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -49,7 +49,7 @@ class NovaService < PacemakerServiceObject
         },
         "nova-multi-compute-vmware" => {
           "unique" => false,
-          "count" => 1
+          "count" => -1
         },
         "nova-multi-compute-xen" => {
           "unique" => false,


### PR DESCRIPTION
The restriction to only one compute node is bad for HA/scale
out reasons, and it seems to be possible to deploy multiple
computes just fine..

(cherry picked from commit 8d370b5c6e8cbcdb3c07452423e5d0e9802b43a5)