### PR TITLE
Move calls to crowbar-nova-set-availability-zone to compute nodes

### DIFF
--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -1,0 +1,58 @@
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module NovaAvailabilityZone
+  def self.fetch_set_az_command_no_arg(node, cookbook_name)
+    keystone_settings = KeystoneHelper.keystone_settings(node, cookbook_name)
+
+    nova_insecure = node[:nova][:ssl][:enabled] && node[:nova][:ssl][:insecure]
+
+    command = [ "/usr/bin/crowbar-nova-set-availability-zone" ]
+    command << "--os-username"
+    command << keystone_settings['admin_user']
+    command << "--os-password"
+    command << keystone_settings['admin_password']
+    command << "--os-tenant-name"
+    command << keystone_settings['default_tenant']
+    command << "--os-auth-url"
+    command << keystone_settings['internal_auth_url']
+    command << "--os-region-name"
+    command << keystone_settings['endpoint_region']
+
+    if keystone_settings['insecure'] || nova_insecure
+      command << "--insecure"
+    end
+
+    command
+  end
+
+  def self.add_arg_to_set_az_command(command_no_arg, compute_node)
+    availability_zone = ""
+    unless compute_node[:crowbar_wall].nil? or compute_node[:crowbar_wall][:openstack].nil?
+      availability_zone = compute_node[:crowbar_wall][:openstack][:availability_zone]
+    end
+
+    command = command_no_arg.clone
+    command << compute_node.hostname
+    # we need an array for the command to avoid command injection with this part
+    command << availability_zone
+
+    # Note: if availability_zone is "", then the command will move the host to
+    # the default availability zone, which is what we want
+
+    command
+  end
+end

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -24,10 +24,6 @@ venv_path = node[:nova][:use_virtualenv] ? "#{nova_path}/.venv" : nil
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-unless node[:nova][:use_gitrepo]
-  package "python-novaclient"
-end
-
 nova_package "api" do
   use_pacemaker_provider node[:nova][:ha][:enabled]
 end

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -416,3 +416,13 @@ template "/etc/nova/nova.conf" do
             )
 end
 
+unless node[:nova][:use_gitrepo]
+  # dependency for crowbar-nova-set-availability-zone
+  package "python-novaclient"
+end
+
+cookbook_file "crowbar-nova-set-availability-zone" do
+  source "crowbar-nova-set-availability-zone"
+  path "/usr/bin/crowbar-nova-set-availability-zone"
+  mode "0755"
+end


### PR DESCRIPTION
Instead of doing N calls (where N is the number of compute nodes) on the
controller, which doesn't scale (it can be slow and make chef-client
take a long time to complete), we just do one call on each compute node.

Except for Hyper-V compute nodes, that are still handled by the
controller due to the fact that they don't have the small utility.