### PR TITLE
Use new do_all recipe to install hyperv bits

### DIFF
--- a/chef/roles/nova-multi-compute-hyperv.rb
+++ b/chef/roles/nova-multi-compute-hyperv.rb
@@ -1,14 +1,7 @@
 name "nova-multi-compute-hyperv"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[hyperv::windows_features]",
-         "recipe[hyperv::setup_networking]",
-         "recipe[hyperv::7zip]",
-         "recipe[hyperv::python]",
-         "recipe[hyperv::python_archive]",
-         "recipe[hyperv::openstack_install]",
-         "recipe[hyperv::config]",
-         "recipe[hyperv::register_services]"
+         "recipe[hyperv::do_all]"
 )
 default_attributes()
 override_attributes()


### PR DESCRIPTION
This allows us to not know about all the hyperv recipes, and the right
order to use.

This depends on https://github.com/crowbar/barclamp-hyperv-compute/pull/22