### PR TITLE
Scale up libvirtd workers for powerful compute hosts

### DIFF
--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -53,7 +53,7 @@
 
       = string_field %w(zvm zvm_xcat_server)
       = string_field %w(zvm zvm_xcat_username)
-      = string_field %w(zvm zvm_xcat_password)
+      = password_field %w(zvm zvm_xcat_password)
       = string_field %w(zvm zvm_diskpool)
       = string_field %w(zvm zvm_diskpool_type)
       = string_field %w(zvm zvm_host)


### PR DESCRIPTION
Partner tested OpenStack on a 8192 CPU machine and quickly ran into
limits on the libvirtd site. Try to scale this up a little.