### PR TITLE
Avoid crowbar_join failing on Nova API being unavailable (bnc#916562)

### DIFF
--- a/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
+++ b/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
@@ -138,7 +138,8 @@ try:
     hosts = c.hosts.list()
 except Exception as e:
     print >> sys.stderr, 'Cannot fetch list of nova hosts: %s' % e
-    sys.exit(1)
+    # Treat this as temp failure as likely its just the API is not up right now
+    sys.exit(69)
 
 try:
     host = [host for host in hosts if host.service == 'compute' and host.host_name == target_host_name][0]

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -379,7 +379,8 @@ command = NovaAvailabilityZone.add_arg_to_set_az_command(command_no_arg, node)
 execute "Set availability zone for #{node.hostname}" do
   command command
   timeout 15
-  returns [0, 68]
+  # Any exit code in the range 60-69 is a tempfail
+  returns [0] + (60..69).to_a
   action :nothing
   subscribes :run, "execute[trigger-nova-own-az-config]", :delayed
 end


### PR DESCRIPTION
When all hosts are rebooted, there is a race on which one
comes up first. Chances are high that compute hots, having
less stuff installed, come up first, and then hit an unavailable
controller node. Ignore those failures.