### PR TITLE
Install Ceph integration on compute nodes if needed

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -138,7 +138,7 @@ if %w(redhat centos suse).include?(node.platform)
       end
 
       # Install Ceph integration if needed
-      cinder_servers = search(:node, "roles:cinder-controller") || []
+      cinder_servers = search_env_filtered(:node, "roles:cinder-controller") || []
       if cinder_servers.length > 0
         cinder_servers[0][:cinder][:volumes].each do |volume|
           next if volume['backend_driver'] != "rbd"

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -184,7 +184,7 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 ceph_user = node[:nova][:rbd][:user]
 ceph_uuid = node[:nova][:rbd][:secret_uuid]
 
-cinder_servers = search(:node, "roles:cinder-controller") || []
+cinder_servers = search_env_filtered(:node, "roles:cinder-controller") || []
 if cinder_servers.length > 0
   cinder_server = cinder_servers[0]
   cinder_insecure = cinder_server[:cinder][:api][:protocol] == 'https' && cinder_server[:cinder][:ssl][:insecure]


### PR DESCRIPTION
When using external Ceph, we still need to setup
the Ceph integration in KVM and nova-compute.