### PR TITLE
Use SSL for nova-metadata when SSL is enabled

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -393,7 +393,7 @@ state_path=/var/lib/nova
 
 # A list of APIs with enabled SSL (list value)
 #enabled_ssl_apis=
-enabled_ssl_apis = <%= @ssl_enabled ? "ec2,osapi_compute" : "" %>
+enabled_ssl_apis = <%= @ssl_enabled ? "ec2,osapi_compute,metadata" : "" %>
 
 # The IP address on which the EC2 API will listen. (string
 # value)


### PR DESCRIPTION
The only reason we were not doing this before is that neutron didn't
support it, and now it does.