### PR TITLE
Allocate a public IP for compute host if DVR is enabled

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -204,6 +204,9 @@ class NovaService < PacemakerServiceObject
             node.save
           end
         end
+        if neutron["attributes"]["neutron"]["use_dvr"]
+          net_svc.allocate_ip "default","public","host", n
+        end
       end
     end unless all_nodes.nil?
 


### PR DESCRIPTION
This is a requirement for DVR, see slide 4 of
http://fr.slideshare.net/carlbaldwin/dvr-slides