### PR TITLE
Split recipes in nova-compute-hyperv role

### DIFF
--- a/chef/roles/nova-multi-compute-hyperv.rb
+++ b/chef/roles/nova-multi-compute-hyperv.rb
@@ -1,7 +1,8 @@
 name "nova-multi-compute-hyperv"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[hyperv::do_all]"
+         "recipe[hyperv::do_setup]",
+         "recipe[hyperv::do_nova]"
 )
 default_attributes()
 override_attributes()


### PR DESCRIPTION
We split the the setup recipe in the hyperv cookbook in two seperate
recipes do_setup and do_nova to make the basic setup recipe usable for
other cookbooks too.

(cherry picked from commit d1155fdbda57f09a7b493bfc623522651bed8df2)

As Jiri is in Vancouver I take over from here: https://github.com/crowbar/barclamp-nova/pull/453
where this has already been reviewed.