### PR TITLE
[tex] Enable the 2.1 API (bsc#934225)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -3466,7 +3466,7 @@ api_insecure=<%= @neutron_insecure ? 'True' : 'False' %>
 #
 
 # Whether the V3 API is enabled or not (boolean value)
-#enabled=false
+enabled=true
 
 # A list of v3 API extensions to never load. Specify the
 # extension aliases here. (list value)


### PR DESCRIPTION
Quite confusingly, the 2.1 API is disabled by default and only enabled
when this is in nova.conf:

[osapi_v3]
enabled=true

Since we configure the computev21 endpoint unconditionally, also enable
the API.

Fix found by Roberto Sassu <rsassu@suse.com>

https://bugzilla.suse.com/show_bug.cgi?id=934225
(cherry picked from commit 7dc1fba0a24282a573e198ef50ee177c76a86f7c)