### PR TITLE
Set cookbook name in metadata

### DIFF
--- a/chef/cookbooks/nova/metadata.rb
+++ b/chef/cookbooks/nova/metadata.rb
@@ -1,9 +1,10 @@
-maintainer       "Opscode, Inc."
-maintainer_email "cookbooks@opscode.com"
-license          "Apache 2.0"
-description      "Installs/Configures nova"
+name "nova"
+maintainer "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
+license "Apache 2.0"
+description "Installs/Configures nova"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3"
+version "0.3"
 
 depends "ceph"
 depends "crowbar-openstack"


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar
framework. I.e. usingthe cookbook as berkshelf dependency.
Also update maintainer email address.