### PR TITLE
Mark xCat password field as being a password field

### DIFF
--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -53,7 +53,7 @@
 
       = string_field %w(zvm zvm_xcat_server)
       = string_field %w(zvm zvm_xcat_username)
-      = string_field %w(zvm zvm_xcat_password)
+      = password_field %w(zvm zvm_xcat_password)
       = string_field %w(zvm zvm_diskpool)
       = string_field %w(zvm zvm_diskpool_type)
       = string_field %w(zvm zvm_host)


### PR DESCRIPTION
otherwise the password is not hidden during typing.