### PR TITLE
Make nova_floating independent of public network

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -225,7 +225,7 @@ class NovaService < PacemakerServiceObject
           end
         end
         if neutron["attributes"]["neutron"]["use_dvr"]
-          net_svc.allocate_ip "default","public","host", n
+          net_svc.enable_interface "default", "nova_floating", n
         end
       end
     end unless all_nodes.nil?


### PR DESCRIPTION
Network notes don't need a public IP allocated,
but they need an interface in the VLAN for nova_floating enabled.

(cherry picked from commit 41d9826a822e4e6a60828ec20ed69d8b42b30f72)