### PR TITLE
Fix catalog_info setting for cinder in nova.conf

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2403,7 +2403,7 @@ xvpvncproxy_host=<%= @bind_host %>
 # <service_type>:<service_name>:<endpoint_type> (string value)
 # Deprecated group/name - [DEFAULT]/cinder_catalog_info
 #catalog_info=volume:cinder:publicURL
-catalog_info=volumev2:cinder:internalURL
+catalog_info=volumev2:cinderv2:internalURL
 
 # Override service catalog lookup with template for cinder
 # endpoint e.g. http://localhost:8776/v1/%(project_id)s


### PR DESCRIPTION
It was referring to volumev2:cinder:internalURL, but should be
volumev2:cinderv2:internalURL (as that's what is registered in the
cinder cookbook).