### PR TITLE
[stoney] increase timeout for synchronization of HA resources (bsc#935462)

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -81,7 +81,9 @@ end
 crowbar_pacemaker_sync_mark "sync-nova_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-nova_ha_resources"
+crowbar_pacemaker_sync_mark "wait-nova_ha_resources" do
+  timeout 120
+end
 
 primitives = []
 


### PR DESCRIPTION
increase timeout for synchronization of HA resources (bsc#935462)

Nova HA resources can take over 1 minute to be set up, as seen by
mkcloud failures in ci.suse.de Jenkins.

https://bugzilla.suse.com/show_bug.cgi?id=935462

(cherry picked from commit f04bd35ef94822f8e229e6cfb5219a16f1d92cb9)