### PR TITLE
Add option to enforce use of config drive

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -128,8 +128,8 @@ if rbd_enabled
 end
 
 # FIXME: These attributes will be removed or re-used
-# with ephemeral storage change. Right now they are 
-# disabled in nova.conf to prevent overwritting 
+# with ephemeral storage change. Right now they are
+# disabled in nova.conf to prevent overwritting
 # multi Ceph backends from Cinder
 ceph_user = node[:nova][:rbd][:user]
 ceph_uuid = node[:nova][:rbd][:secret_uuid]
@@ -302,6 +302,7 @@ template "/etc/nova/nova.conf" do
             :libvirt_migration => node[:nova]["use_migration"],
             :libvirt_enable_multipath => node[:nova][:libvirt_use_multipath],
             :shared_instances => node[:nova]["use_shared_instance_storage"],
+            :force_config_drive => node[:nova]["force_config_drive"],
             :glance_server_protocol => glance_server_protocol,
             :glance_server_host => glance_server_host,
             :glance_server_port => glance_server_port,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1888,7 +1888,9 @@ ram_allocation_ratio=<%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 
 # Set to force injection to take place on a config drive (if
 # set, valid options are: always) (string value)
-#force_config_drive=<None>
+<% if @force_config_drive %>
+force_config_drive=always
+<% end -%>
 
 # Name and optionally path of the tool used for ISO image
 # creation (string value)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -21,6 +21,7 @@
       "use_migration": false,
       "use_syslog": false,
       "neutron_url_timeout": 30,
+      "force_config_drive": false,
       "vnc_keymap": "en-us",
       "scheduler": {
         "ram_allocation_ratio": 1.0,
@@ -79,7 +80,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 32,
+      "schema-revision": 33,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -32,6 +32,7 @@
             "itxt_instance": { "type": "str", "required": true },
             "neutron_metadata_proxy_shared_secret": { "type": "str" },
             "neutron_url_timeout": {"type": "int"},
+            "force_config_drive": { "type": "bool", "required": true },
             "vnc_keymap": { "type": "str" , "required": true },
             "scheduler": {
               "type": "map",

--- a/chef/data_bags/crowbar/migrate/nova/033_add_configdrive.rb
+++ b/chef/data_bags/crowbar/migrate/nova/033_add_configdrive.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  unless a.has_key? "force_config_drive"
+    a["force_config_drive"] = ta["force_config_drive"]
+  end
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  unless ta.has_key? "force_config_drive"
+    a.delete("force_config_drive")
+  end
+  return a, d
+end


### PR DESCRIPTION
This is useful in environments where the dhcp-agent is disabled,
which means there is no neutron/nova metadata proxy available.