### PR TITLE
Block device allocation configuration (bsc#937800)

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -119,3 +119,9 @@ default[:nova][:ha][:ports][:metadata] = 5552
 default[:nova][:ha][:ports][:objectstore] = 5553
 default[:nova][:ha][:ports][:novncproxy] = 5554
 default[:nova][:ha][:ports][:xvpvncproxy] = 5555
+
+#
+# Block device settings
+#
+default[:nova][:block_device][:allocate_retries] = 60
+default[:nova][:block_device][:allocate_retries_interval] = 3

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -903,6 +903,7 @@ instance_usage_audit=True
 # Number of times to retry block device allocation on failures
 # (integer value)
 #block_device_allocate_retries=60
+block_device_allocate_retries=<%= node[:nova][:block_device][:allocate_retries] %>
 
 # The number of times to attempt to reap an instance's files.
 # (integer value)
@@ -950,6 +951,7 @@ instance_usage_audit=True
 # Waiting time interval (seconds) between block device
 # allocation retries on failures (integer value)
 #block_device_allocate_retries_interval=3
+block_device_allocate_retries_interval=<%= node[:nova][:block_device][:allocate_retries_interval] %>
 
 # Action to take if a running deleted instance is
 # detected.Valid options are 'noop', 'log', 'shutdown', or

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -99,6 +99,10 @@
           "certfile": "",
           "keyfile": ""
         }
+      },
+      "block_device": {
+        "allocate_retries": 60,
+        "allocate_retries_interval": 3
       }
     }
   },
@@ -106,7 +110,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 24,
+      "schema-revision": 25,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -100,6 +100,12 @@
                   }
                 }
               }
+            },
+            "block_device": {
+              "type": "map", "required": true, "mapping": {
+                "allocate_retries": { "type": "number", "required" : true },
+                "allocate_retries_interval": { "type": "number", "required" : true }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/migrate/nova/025_configure_block_device_allocation.rb
+++ b/chef/data_bags/crowbar/migrate/nova/025_configure_block_device_allocation.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.has_key? "block_device"
+    a["block_device"] = ta["block_device"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.has_key? "block_device"
+    a.delete("block_device")
+  end
+  return a, d
+end


### PR DESCRIPTION
Make block_device_allocate_retries and
block_device_allocate_retries_interval configurable from
the crowbar web ui in the raw view. See also
https://bugzilla.suse.com/show_bug.cgi?id=937800

(cherry picked from commit a876afb762a5d3c52526622a4c48cb43ce410c5a)

Conflicts:
    chef/data_bags/crowbar/bc-template-nova.json
