### PR TITLE
Raise Nova defaults to avoid hangs on mass-deployment (bsc#944489)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -12,7 +12,7 @@
 #amqp_auto_delete=false
 
 # Size of RPC connection pool. (integer value)
-#rpc_conn_pool_size=30
+rpc_conn_pool_size=64
 
 # Qpid broker hostname. (string value)
 #qpid_hostname=localhost
@@ -162,7 +162,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 #matchmaker_heartbeat_ttl=600
 
 # Size of RPC greenthread pool. (integer value)
-#rpc_thread_pool_size=64
+rpc_thread_pool_size=256
 
 # Driver or drivers to handle sending notifications. (multi
 # valued)


### PR DESCRIPTION
It turns out Nova does not handle running out of RPC connections
gracefully, but rather misbehaving badly and failing VMs. Since
you're quickly running out of RPC threads when talking to neutron
while launching a massive number of VMs in parallel, we should
raise the upper limit to a saner value.

Backport of: https://github.com/crowbar/crowbar-openstack/pull/49
