### PR TITLE
Adds sqlalchemy pool values for nova.

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -28,6 +28,12 @@ default[:nova][:db][:password] = nil
 default[:nova][:db][:user] = "nova"
 default[:nova][:db][:database] = "nova"
 
+# SQLAlchemy parameters
+default[:nova][:db][:max_pool_size] = nil
+default[:nova][:db][:max_overflow] = nil
+default[:nova][:db][:pool_timeout] = nil
+default[:nova][:db][:min_pool_size] = nil
+
 # Feature settings
 default[:nova][:use_migration] = false
 default[:nova][:use_shared_instance_storage] = false

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2740,12 +2740,18 @@ connection=<%= @database_connection %>
 # Deprecated group/name - [DEFAULT]/sql_min_pool_size
 # Deprecated group/name - [DATABASE]/sql_min_pool_size
 #min_pool_size=1
+<% unless node[:nova][:db][:min_pool_size].nil? -%>
+min_pool_size=<%= node[:nova][:db][:min_pool_size] -%>
+<% end -%>
 
 # Maximum number of SQL connections to keep open in a pool
 # (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_pool_size
 # Deprecated group/name - [DATABASE]/sql_max_pool_size
 #max_pool_size=<None>
+<% unless node[:nova][:db][:max_pool_size].nil? -%>
+max_pool_size=<%= node[:nova][:db][:max_pool_size] %>
+<% end -%>
 
 # Maximum db connection retries during startup. (setting -1
 # implies an infinite retry count) (integer value)
@@ -2764,6 +2770,9 @@ connection=<%= @database_connection %>
 # Deprecated group/name - [DEFAULT]/sql_max_overflow
 # Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
 #max_overflow=<None>
+<% unless node[:nova][:db][:max_overflow].nil? -%>
+max_overflow=<%= node[:nova][:db][:max_overflow] %>
+<% end -%>
 
 # Verbosity of SQL debugging information. 0=None,
 # 100=Everything (integer value)
@@ -2779,6 +2788,9 @@ connection=<%= @database_connection %>
 # (integer value)
 # Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
 #pool_timeout=<None>
+<% unless node[:nova][:db][:pool_timeout].nil? -%>
+pool_timeout=<%= node[:nova][:db][:pool_timeout] %>
+<% end -%>
 
 # Enable the experimental use of database reconnect on
 # connection lost (boolean value)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -110,7 +110,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 25,
+      "schema-revision": 26,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -55,7 +55,11 @@
               "mapping": {
                 "password": { "type": "str", "required": true },
                 "user": { "type": "str", "required": true },
-                "database": { "type": "str", "required": true }
+                "database": { "type": "str", "required": true },
+                "max_pool_size": { "type": "int", "required": false },
+                "max_overflow": { "type": "int", "required": false },
+                "pool_timeout": { "type": "int", "required": false },
+                "min_pool_size": { "type": "int", "required": false }
               }
             },
             "rbd": {

--- a/chef/data_bags/crowbar/migrate/nova/026_add_sqlalchemy_pool_values.rb
+++ b/chef/data_bags/crowbar/migrate/nova/026_add_sqlalchemy_pool_values.rb
@@ -1,0 +1,21 @@
+def upgrade(ta, td, a, d)
+  # NOTE(toabctl): we do nothing here because all the added keys
+  # are not required
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["db"].key? "max_pool_size"
+    a["db"].delete "max_pool_size"
+  end
+  unless ta["db"].key? "min_pool_size"
+    a["db"].delete "min_pool_size"
+  end
+  unless ta["db"].key? "max_overflow"
+    a["db"].delete "max_overflow"
+  end
+  unless ta["db"].key? "pool_timeout"
+    a["db"].delete "pool_timeout"
+  end
+  return a, d
+end


### PR DESCRIPTION
Add sqlalchemy pool values to avoid hardcoding DB pool values for nova.

Co-Authored-by: Thomas Bechtold tbechtold@suse.com
(cherry picked from commit 91b8174fcd15b799c8d33e2e7733d12202e41da9)
